### PR TITLE
Changed downstream rules 

### DIFF
--- a/rules/downstream.smk
+++ b/rules/downstream.smk
@@ -26,13 +26,13 @@ rule dm_regions_bed:
 
 rule dm_regions_bed_special:
 	input:
-		f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/A_v_B_diploid.txt" if config["DIPLOID_ONLY"] else f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/A_v_B_polyploid.txt"
+		f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/A_v_B_diploid.txt" if config["DIPLOID_ONLY"] else (f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/A_v_B_polyploid.txt")
 	output:
-		f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/A_v_B_diploid_sig_sorted.bed" if config["DIPLOID_ONLY"] else  f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/A_v_B_polyploid_sig_sorted.bed"
+		f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/A_v_B_diploid_sig_sorted.bed" if config["DIPLOID_ONLY"] else (f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/A_v_B_polyploid_sig_sorted.bed")
 	log:
 		f"logs/dm_region_{{context}}_special.log"
 	params:
-		f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/A_v_B_diploid_sig" if config["DIPLOID_ONLY"] else f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/A_v_B_polyploid_sig"
+		f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/A_v_B_diploid_sig" if config["DIPLOID_ONLY"] else (f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/A_v_B_polyploid_sig")
 	conda:
 		"../envs/environment_downstream.yaml"
 	shell:

--- a/rules/downstream.smk
+++ b/rules/downstream.smk
@@ -8,192 +8,225 @@ import os.path
 
 # The first downstream rule takes the dmrseq output and creates a bed file with all significant DMRs (specifically DMRs with q-values < 0.05)
 
+
 rule dm_regions_bed:
-	input:
-		f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/parent{{one_or_two}}_v_allo.txt"
-	output:
-		f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/parent{{one_or_two}}_v_allo_sig_sorted.bed"
-	log:
-		f"logs/dm_region_{{context}}_p{{one_or_two}}.log"
-	params:
-		f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/parent{{one_or_two}}_v_allo_sig"
-	conda:
-		"../envs/environment_downstream.yaml"
-	shell:
-		"Rscript scripts/significantGenesToBed.R {input} {params}"
+    input:
+        f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/parent{{one_or_two}}_v_allo.txt",
+    output:
+        f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/parent{{one_or_two}}_v_allo_sig_sorted.bed",
+    log:
+        f"logs/dm_region_{{context}}_p{{one_or_two}}.log",
+    params:
+        f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/parent{{one_or_two}}_v_allo_sig",
+    conda:
+        "../envs/environment_downstream.yaml"
+    shell:
+        "Rscript scripts/significantGenesToBed.R {input} {params}"
+
 
 # The first downstream rule for special mode: diploid vs diploid or polyploid vs polyploid. Read above for a short explanation of the rule.
 
+
 rule dm_regions_bed_special:
-	input:
-		f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/A_v_B_diploid.txt" if config["DIPLOID_ONLY"] else (f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/A_v_B_polyploid.txt")
-	output:
-		f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/A_v_B_diploid_sig_sorted.bed" if config["DIPLOID_ONLY"] else (f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/A_v_B_polyploid_sig_sorted.bed")
-	log:
-		f"logs/dm_region_{{context}}_special.log"
-	params:
-		f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/A_v_B_diploid_sig" if config["DIPLOID_ONLY"] else (f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/A_v_B_polyploid_sig")
-	conda:
-		"../envs/environment_downstream.yaml"
-	shell:
-		"Rscript scripts/significantGenesToBed.R {input} {params}"
+    input:
+        f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/A_v_B_diploid.txt" if config[
+            "DIPLOID_ONLY"
+        ] else (f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/A_v_B_polyploid.txt"),
+    output:
+        f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/A_v_B_diploid_sig_sorted.bed" if config[
+            "DIPLOID_ONLY"
+        ] else (
+            f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/A_v_B_polyploid_sig_sorted.bed"
+        ),
+    log:
+        f"logs/dm_region_{{context}}_special.log",
+    params:
+        f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/A_v_B_diploid_sig" if config[
+            "DIPLOID_ONLY"
+        ] else (f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/A_v_B_polyploid_sig"),
+    conda:
+        "../envs/environment_downstream.yaml"
+    shell:
+        "Rscript scripts/significantGenesToBed.R {input} {params}"
+
 
 # The second downsteam rule checks the gene regions provided in the annotation file and finds any overlaps with DMRs. The output includes all genes showing an overlap with the overlapping DMR.
 
+
 rule bedtools_intersect_1:
-	input:
-		i1 = f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/parent1_v_allo_sig_sorted.bed"
-	output:
-		o1 = f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/parent1_v_allo_genes_overlap.txt"
-	log:
-		f"logs/bedtools_{{context}}_p1.log"
-	params:
-		anno1 = config["ANNOTATION_PARENT_1"]
-	conda:
-		"../envs/environment_downstream.yaml"
-	shell:
-		"bedtools intersect -a {params.anno1} -b {input.i1} -wo > {output.o1}"
+    input:
+        i1=(
+            f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/parent1_v_allo_sig_sorted.bed"
+        ),
+    output:
+        o1=f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/parent1_v_allo_genes_overlap.txt",
+    log:
+        f"logs/bedtools_{{context}}_p1.log",
+    params:
+        anno1=config["ANNOTATION_PARENT_1"],
+    conda:
+        "../envs/environment_downstream.yaml"
+    shell:
+        "bedtools intersect -a {params.anno1} -b {input.i1} -wo > {output.o1}"
+
 
 rule bedtools_intersect_2:
-	input:
-		i2 = f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/parent2_v_allo_sig_sorted.bed"
-	output:
-		o2 = f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/parent2_v_allo_genes_overlap.txt"
-	log:
-		f"logs/bedtools_{{context}}_p2.log"
-	params:
-		anno2 = config["ANNOTATION_PARENT_2"]
-	conda:
-		"../envs/environment_downstream.yaml"
-	shell:
-		"bedtools intersect -a {params.anno2} -b {input.i2} -wo > {output.o2}"
+    input:
+        i2=(
+            f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/parent2_v_allo_sig_sorted.bed"
+        ),
+    output:
+        o2=f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/parent2_v_allo_genes_overlap.txt",
+    log:
+        f"logs/bedtools_{{context}}_p2.log",
+    params:
+        anno2=config["ANNOTATION_PARENT_2"],
+    conda:
+        "../envs/environment_downstream.yaml"
+    shell:
+        "bedtools intersect -a {params.anno2} -b {input.i2} -wo > {output.o2}"
+
 
 # The second downstream rule for special mode: diploid vs diploid or polyploid vs polyploid. Read above for a short explanation of the rule.
 
+
 rule bedtools_intersect_special_diploid:
-	input:
-		f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/A_v_B_diploid_sig_sorted.bed"
-	output:
-		f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/A_v_B_diploid_genes_overlap.txt"
-	log:
-		f"logs/bedtools_{{context}}_special.log"
-	params:
-		anno1 = config["ANNOTATION_PARENT_1"],
-		anno2 = config["ANNOTATION_PARENT_2"]
-	conda:
-		"../envs/environment_downstream.yaml"
-	shell:
-		"bedtools intersect -a {params.anno1} -b {input} -wo > {output}" if (sum(samples.origin == "parent1") > 0) else "bedtools intersect -a {params.anno2} -b {input} -wo > {output}"
+    input:
+        f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/A_v_B_diploid_sig_sorted.bed",
+    output:
+        f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/A_v_B_diploid_genes_overlap.txt",
+    log:
+        f"logs/bedtools_{{context}}_special.log",
+    params:
+        anno1=config["ANNOTATION_PARENT_1"],
+        anno2=config["ANNOTATION_PARENT_2"],
+    conda:
+        "../envs/environment_downstream.yaml"
+    shell:
+        "bedtools intersect -a {params.anno1} -b {input} -wo > {output}" if (
+            sum(samples.origin == "parent1") > 0
+        ) else "bedtools intersect -a {params.anno2} -b {input} -wo > {output}"
+
 
 rule bedtools_intersect_special_polyploid_1:
-	input:
-		f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/A_v_B_polyploid_sig_sorted.bed"
-	output:
-		f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/A_v_B_polyploid_genes_overlap_1.txt"
-	log:
-		f"logs/bedtools_{{context}}_special_1.log"
-	params:
-		anno1 = config["ANNOTATION_PARENT_1"]
-	conda:
-		"../envs/environment_downstream.yaml"
-	shell:
-		"bedtools intersect -a {params.anno1} -b {input} -wo > {output}"
+    input:
+        f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/A_v_B_polyploid_sig_sorted.bed",
+    output:
+        f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/A_v_B_polyploid_genes_overlap_1.txt",
+    log:
+        f"logs/bedtools_{{context}}_special_1.log",
+    params:
+        anno1=config["ANNOTATION_PARENT_1"],
+    conda:
+        "../envs/environment_downstream.yaml"
+    shell:
+        "bedtools intersect -a {params.anno1} -b {input} -wo > {output}"
+
 
 rule bedtools_intersect_special_polyploid_2:
-	input:
-		f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/A_v_B_polyploid_sig_sorted.bed"
-	output:
-		f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/A_v_B_polyploid_genes_overlap_2.txt"
-	log:
-		f"logs/bedtools_{{context}}_special_2.log"
-	params:
-		anno2 = config["ANNOTATION_PARENT_2"]
-	conda:
-		"../envs/environment_downstream.yaml"
-	shell:
-		"bedtools intersect -a {params.anno2} -b {input} -wo > {output}"
+    input:
+        f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/A_v_B_polyploid_sig_sorted.bed",
+    output:
+        f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/A_v_B_polyploid_genes_overlap_2.txt",
+    log:
+        f"logs/bedtools_{{context}}_special_2.log",
+    params:
+        anno2=config["ANNOTATION_PARENT_2"],
+    conda:
+        "../envs/environment_downstream.yaml"
+    shell:
+        "bedtools intersect -a {params.anno2} -b {input} -wo > {output}"
+
 
 # The third and final rule for downstream analyses. With overlap information and DMR information, we generate a summary file including gene ID of the genes overlapping with DMRs, all ranges for gene regions and DMRs and methylation status. Methylation status is based on the statistics given by the dmrseq output, taking condition 'A' as reference (i.e. increase means increase compared to condition 'A')
 
+
 rule dmr_genes_1:
-	input:
-		i1 = f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/parent1_v_allo_genes_overlap.txt",
-		dm1 = f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/parent1_v_allo.txt"
-	output:
-		o1 = f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/DM_genes_parent1_v_allo_{{context}}.txt"
-	log:
-		f"logs/dmr_genes_{{context}}_p1.log"
-	params:
-		geneID1 = config["GENE_ID_PARENT_1"],
-		o1 = lambda w, output: os.path.splitext(output.o1)[0]
-	conda:
-		"../envs/environment_downstream.yaml"
-	shell:
-		"Rscript scripts/DMGeneSummary.R {input.i1} {input.dm1} {params.geneID1} {params.o1}"
+    input:
+        i1=f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/parent1_v_allo_genes_overlap.txt",
+        dm1=f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/parent1_v_allo.txt",
+    output:
+        o1=f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/DM_genes_parent1_v_allo_{{context}}.txt",
+    log:
+        f"logs/dmr_genes_{{context}}_p1.log",
+    params:
+        geneID1=config["GENE_ID_PARENT_1"],
+        o1=lambda w, output: os.path.splitext(output.o1)[0],
+    conda:
+        "../envs/environment_downstream.yaml"
+    shell:
+        "Rscript scripts/DMGeneSummary.R {input.i1} {input.dm1} {params.geneID1} {params.o1}"
+
 
 rule dmr_genes_2:
-	input:
-		i2 = f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/parent2_v_allo_genes_overlap.txt",
-		dm2 = f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/parent2_v_allo.txt"
-	output:
-		o2 = f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/DM_genes_parent2_v_allo_{{context}}.txt"
-	log:
-		f"logs/dmr_genes_{{context}}_p2.log"
-	params:
-		geneID2 = config["GENE_ID_PARENT_2"],
-		o2 = lambda w, output: os.path.splitext(output.o2)[0]
-	conda:
-		"../envs/environment_downstream.yaml"
-	shell:
-		"Rscript scripts/DMGeneSummary.R {input.i2} {input.dm2} {params.geneID2} {params.o2}"
+    input:
+        i2=f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/parent2_v_allo_genes_overlap.txt",
+        dm2=f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/parent2_v_allo.txt",
+    output:
+        o2=f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/DM_genes_parent2_v_allo_{{context}}.txt",
+    log:
+        f"logs/dmr_genes_{{context}}_p2.log",
+    params:
+        geneID2=config["GENE_ID_PARENT_2"],
+        o2=lambda w, output: os.path.splitext(output.o2)[0],
+    conda:
+        "../envs/environment_downstream.yaml"
+    shell:
+        "Rscript scripts/DMGeneSummary.R {input.i2} {input.dm2} {params.geneID2} {params.o2}"
+
 
 # The third downstream rules for special modes: diploid vs diploid (first below) or polyploid vs polyploid (second below). Read above for a short explanation of the rule.
 
+
 rule dmr_genes_special_diploid:
-	input:
-		i1 = f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/A_v_B_diploid_genes_overlap.txt",
-		dm1 = f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/A_v_B_diploid.txt"
-	output:
-		o1 = f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/DM_genes_A_v_B_diploid_{{context}}.txt"
-	log:
-		f"logs/dmr_genes_{{context}}_special_diploid.log"
-	params:
-		geneID1 = config["GENE_ID_PARENT_1"],
-		geneID2 = config["GENE_ID_PARENT_2"],
-		o1 = lambda w, output: os.path.splitext(output.o1)[0]
-	conda:
-		"../envs/environment_downstream.yaml"
-	shell:
-		"Rscript scripts/DMGeneSummary.R {input.i1} {input.dm1} {params.geneID1} {params.o1}" if (sum(samples.origin == "parent1") > 0) else "Rscript scripts/DMGeneSummary.R {input.i1} {input.dm1} {params.geneID2} {params.o1}"
+    input:
+        i1=f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/A_v_B_diploid_genes_overlap.txt",
+        dm1=f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/A_v_B_diploid.txt",
+    output:
+        o1=f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/DM_genes_A_v_B_diploid_{{context}}.txt",
+    log:
+        f"logs/dmr_genes_{{context}}_special_diploid.log",
+    params:
+        geneID1=config["GENE_ID_PARENT_1"],
+        geneID2=config["GENE_ID_PARENT_2"],
+        o1=lambda w, output: os.path.splitext(output.o1)[0],
+    conda:
+        "../envs/environment_downstream.yaml"
+    shell:
+        "Rscript scripts/DMGeneSummary.R {input.i1} {input.dm1} {params.geneID1} {params.o1}" if (
+            sum(samples.origin == "parent1") > 0
+        ) else "Rscript scripts/DMGeneSummary.R {input.i1} {input.dm1} {params.geneID2} {params.o1}"
+
 
 rule dmr_genes_special_polyploid_1:
-	input:
-		i1 = f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/A_v_B_polyploid_genes_overlap_1.txt",
-		dm1 = f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/A_v_B_polyploid.txt"
-	output:
-		o1 = f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/DM_genes_A_v_B_polyploid_{{context}}_1.txt"
-	log:
-		f"logs/dmr_genes_{{context}}_special_polyploid1.log"
-	params:
-		geneID1 = config["GENE_ID_PARENT_1"],
-		o1 = lambda w, output: os.path.splitext(output.o1)[0]
-	conda:
-		"../envs/environment_downstream.yaml"
-	shell:
-		"Rscript scripts/DMGeneSummary.R {input.i1} {input.dm1} {params.geneID1} {params.o1}"
+    input:
+        i1=f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/A_v_B_polyploid_genes_overlap_1.txt",
+        dm1=f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/A_v_B_polyploid.txt",
+    output:
+        o1=f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/DM_genes_A_v_B_polyploid_{{context}}_1.txt",
+    log:
+        f"logs/dmr_genes_{{context}}_special_polyploid1.log",
+    params:
+        geneID1=config["GENE_ID_PARENT_1"],
+        o1=lambda w, output: os.path.splitext(output.o1)[0],
+    conda:
+        "../envs/environment_downstream.yaml"
+    shell:
+        "Rscript scripts/DMGeneSummary.R {input.i1} {input.dm1} {params.geneID1} {params.o1}"
+
 
 rule dmr_genes_special_polyploid_2:
-	input:
-		i1 = f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/A_v_B_polyploid_genes_overlap_2.txt",
-		dm1 = f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/A_v_B_polyploid.txt"
-	output:
-		o1 = f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/DM_genes_A_v_B_polyploid_{{context}}_2.txt"
-	log:
-		f"logs/dmr_genes_{{context}}_special_polyploid2.log"
-	params:
-		geneID2 = config["GENE_ID_PARENT_2"],
-		o2 = lambda w, output: os.path.splitext(output.o1)[0]
-	conda:
-		"../envs/environment_downstream.yaml"
-	shell:
-		"Rscript scripts/DMGeneSummary.R {input.i1} {input.dm1} {params.geneID2} {params.o2}"
+    input:
+        i1=f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/A_v_B_polyploid_genes_overlap_2.txt",
+        dm1=f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/A_v_B_polyploid.txt",
+    output:
+        o1=f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/DM_genes_A_v_B_polyploid_{{context}}_2.txt",
+    log:
+        f"logs/dmr_genes_{{context}}_special_polyploid2.log",
+    params:
+        geneID2=config["GENE_ID_PARENT_2"],
+        o2=lambda w, output: os.path.splitext(output.o1)[0],
+    conda:
+        "../envs/environment_downstream.yaml"
+    shell:
+        "Rscript scripts/DMGeneSummary.R {input.i1} {input.dm1} {params.geneID2} {params.o2}"

--- a/rules/downstream.smk
+++ b/rules/downstream.smk
@@ -28,7 +28,7 @@ rule dm_regions_bed_special:
 	input:
 		f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/A_v_B_diploid.txt" if config["DIPLOID_ONLY"] else f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/A_v_B_polyploid.txt"
 	output:
-		f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/A_v_B_diploid_sig_sorted.bed" if config["DIPLOID_ONLY"] else f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/A_v_B_polyploid_sig_sorted.bed"
+		f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/A_v_B_diploid_sig_sorted.bed" if config["DIPLOID_ONLY"] else  f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/A_v_B_polyploid_sig_sorted.bed"
 	log:
 		f"logs/dm_region_{{context}}_special.log"
 	params:

--- a/rules/downstream.smk
+++ b/rules/downstream.smk
@@ -70,11 +70,11 @@ rule bedtools_intersect_2:
 
 # The second downstream rule for special mode: diploid vs diploid or polyploid vs polyploid. Read above for a short explanation of the rule.
 
-rule bedtools_intersect_special:
+rule bedtools_intersect_special_diploid:
 	input:
-		f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/A_v_B_diploid_sig_sorted.bed" if config["DIPLOID_ONLY"] else f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/A_v_B_polyploid_sig_sorted.bed"
+		f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/A_v_B_diploid_sig_sorted.bed"
 	output:
-		f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/A_v_B_diploid_genes_overlap.txt" if config["DIPLOID_ONLY"] else f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/A_v_B_polyploid_genes_overlap.txt"
+		f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/A_v_B_diploid_genes_overlap.txt"
 	log:
 		f"logs/bedtools_{{context}}_special.log"
 	params:
@@ -83,7 +83,35 @@ rule bedtools_intersect_special:
 	conda:
 		"../envs/environment_downstream.yaml"
 	shell:
-		"bedtools intersect -a {params.anno1} -b {input} -wo > {output}" if (sum(samples.origin == "parent1") > 0) else ("bedtools intersect -a {params.anno2} -b {input} -wo > {output}" if (sum(samples.origin == "parent2") > 0) else "bedtools intersect -a {params.anno1} -b {input} -wo > {output}; bedtools intersect -a {params.anno2} -b {input} -wo >> {output}")
+		"bedtools intersect -a {params.anno1} -b {input} -wo > {output}" if (sum(samples.origin == "parent1") > 0) else "bedtools intersect -a {params.anno2} -b {input} -wo > {output}"
+
+rule bedtools_intersect_special_polyploid_1:
+	input:
+		f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/A_v_B_polyploid_sig_sorted.bed"
+	output:
+		f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/A_v_B_polyploid_genes_overlap_1.txt"
+	log:
+		f"logs/bedtools_{{context}}_special_1.log"
+	params:
+		anno1 = config["ANNOTATION_PARENT_1"]
+	conda:
+		"../envs/environment_downstream.yaml"
+	shell:
+		"bedtools intersect -a {params.anno1} -b {input} -wo > {output}"
+
+rule bedtools_intersect_special_polyploid_2:
+	input:
+		f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/A_v_B_polyploid_sig_sorted.bed"
+	output:
+		f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/A_v_B_polyploid_genes_overlap_2.txt"
+	log:
+		f"logs/bedtools_{{context}}_special_2.log"
+	params:
+		anno2 = config["ANNOTATION_PARENT_2"]
+	conda:
+		"../envs/environment_downstream.yaml"
+	shell:
+		"bedtools intersect -a {params.anno2} -b {input} -wo > {output}"
 
 # The third and final rule for downstream analyses. With overlap information and DMR information, we generate a summary file including gene ID of the genes overlapping with DMRs, all ranges for gene regions and DMRs and methylation status. Methylation status is based on the statistics given by the dmrseq output, taking condition 'A' as reference (i.e. increase means increase compared to condition 'A')
 
@@ -140,7 +168,7 @@ rule dmr_genes_special_diploid:
 
 rule dmr_genes_special_polyploid_1:
 	input:
-		i1 = f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/A_v_B_polyploid_genes_overlap.txt",
+		i1 = f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/A_v_B_polyploid_genes_overlap_1.txt",
 		dm1 = f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/A_v_B_polyploid.txt"
 	output:
 		o1 = f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/DM_genes_A_v_B_polyploid_{{context}}_1.txt"
@@ -156,7 +184,7 @@ rule dmr_genes_special_polyploid_1:
 
 rule dmr_genes_special_polyploid_2:
 	input:
-		i1 = f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/A_v_B_polyploid_genes_overlap.txt",
+		i1 = f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/A_v_B_polyploid_genes_overlap_2.txt",
 		dm1 = f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/A_v_B_polyploid.txt"
 	output:
 		o1 = f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/DM_genes_A_v_B_polyploid_{{context}}_2.txt"


### PR DESCRIPTION
Split DMR-annotation intersection steps into specific rules for diploid and two polyploid sides. Now the output for `POLYPLOID_ONLY` mode should split DM genes into two files with different gene lists. Addresses #104 