### PR TITLE
Log and benchmark fixes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,6 @@ name: ARPEGGIO_run
 # events but only for the master branch. Added trigger to publishhed and created 
 # releases as well
 on:
-  push:
   pull_request:
     branches: [ master ]
   release:

--- a/rules/alignment.smk
+++ b/rules/alignment.smk
@@ -12,7 +12,7 @@ rule bismark_prepare_genome_1:
     output:
         control=f"{GENOME_1}Bisulfite_Genome/CT_conversion/genome_mfa.CT_conversion.fa",
     log:
-        f"logs/bismark_prepare_genome_1.log",
+        f"{OUTPUT_DIR}logs/bismark_prepare_genome_1.log",
     params:
         genome1=lambda w, output: os.path.split(
             os.path.split(os.path.split(output.control)[0])[0]
@@ -32,7 +32,7 @@ rule bismark_prepare_genome_2:
     output:
         control=f"{GENOME_2}Bisulfite_Genome/CT_conversion/genome_mfa.CT_conversion.fa",
     log:
-        f"logs/bismark_prepare_genome_2.log",
+        f"{OUTPUT_DIR}logs/bismark_prepare_genome_2.log",
     params:
         genome2=lambda w, output: os.path.split(
             os.path.split(os.path.split(output.control)[0])[0]
@@ -62,7 +62,7 @@ rule bismark_alignment_SE_1:
         if config["RUN_TRIMMING"]
         else f"{OUTPUT_DIR}Bismark/{{sample}}_1/1.{{sample}}_bismark_bt2_SE_report.txt",
     log:
-        f"logs/bismark_alignment_{{sample}}_SE_1.log",
+        f"{OUTPUT_DIR}logs/bismark_alignment_{{sample}}_SE_1.log",
     params:
         output=lambda w, output: os.path.split(output.sample)[0],
         genome1=lambda w, input: os.path.split(
@@ -96,7 +96,7 @@ rule bismark_alignment_SE_2:
         if config["RUN_TRIMMING"]
         else f"{OUTPUT_DIR}Bismark/{{sample}}_2/2.{{sample}}_bismark_bt2_SE_report.txt",
     log:
-        f"logs/bismark_alignment_{{sample}}_SE_2.log",
+        f"{OUTPUT_DIR}logs/bismark_alignment_{{sample}}_SE_2.log",
     params:
         output=lambda w, output: os.path.split(output.sample)[0],
         genome2=lambda w, input: os.path.split(
@@ -133,7 +133,7 @@ rule bismark_alignment_PE_1:
         if config["RUN_TRIMMING"]
         else f"{OUTPUT_DIR}Bismark/{{sample}}_1/1.{{sample}}_{str(config['PAIR_1'])}_bismark_bt2_PE_report.txt",
     log:
-        f"logs/bismark_alignment_{{sample}}_PE_1.log",
+        f"{OUTPUT_DIR}logs/bismark_alignment_{{sample}}_PE_1.log",
     params:
         output=lambda w, output: os.path.split(output.sample)[0],
         genome1=lambda w, input: os.path.split(
@@ -170,7 +170,7 @@ rule bismark_alignment_PE_2:
         if config["RUN_TRIMMING"]
         else f"{OUTPUT_DIR}Bismark/{{sample}}_2/2.{{sample}}_{str(config['PAIR_1'])}_bismark_bt2_PE_report.txt",
     log:
-        f"logs/bismark_alignment_{{sample}}_PE_2.log",
+        f"{OUTPUT_DIR}logs/bismark_alignment_{{sample}}_PE_2.log",
     params:
         output=lambda w, output: os.path.split(output.sample)[0],
         genome2=lambda w, input: os.path.split(

--- a/rules/alignment.smk
+++ b/rules/alignment.smk
@@ -22,7 +22,7 @@ rule bismark_prepare_genome_1:
     conda:
         "../envs/environment.yaml"
     shell:
-        "bismark_genome_preparation {params.genome1} 2>&1 {log}"
+        "bismark_genome_preparation {params.genome1} 2> {log}"
 
 
 ## Run Bismark to prepare synthetic bisulfite converted genomes
@@ -42,7 +42,7 @@ rule bismark_prepare_genome_2:
     conda:
         "../envs/environment.yaml"
     shell:
-        "bismark_genome_preparation {params.genome2} 2>&1 {log}"
+        "bismark_genome_preparation {params.genome2} 2> {log}"
 
 
 ## Run Bismark to perform alignment to the first parental genome (GENOME_PARENT_1) if reads are single-end.
@@ -76,7 +76,7 @@ rule bismark_alignment_SE_1:
         "../envs/environment.yaml"
     threads: CORES
     shell:
-        "bismark --prefix {params.prefix} --multicore {params.bismark_cores}  -o {params.output} --temp_dir {params.output} --genome {params.genome1} {input.fastq} 2>&1 {log}"
+        "bismark --prefix {params.prefix} --multicore {params.bismark_cores}  -o {params.output} --temp_dir {params.output} --genome {params.genome1} {input.fastq} 2> {log}"
 
 
 ## Run Bismark to perform alignment to the second parental genome (GENOME_PARENT_2) if reads are single-end.
@@ -110,7 +110,7 @@ rule bismark_alignment_SE_2:
         "../envs/environment.yaml"
     threads: CORES
     shell:
-        "bismark --prefix {params.prefix} --multicore {params.bismark_cores}  -o {params.output} --temp_dir {params.output} --genome {params.genome2} {input.fastq} 2>&1 {log}"
+        "bismark --prefix {params.prefix} --multicore {params.bismark_cores}  -o {params.output} --temp_dir {params.output} --genome {params.genome2} {input.fastq} 2> {log}"
 
 
 ## Run Bismark to perform alignment to the first parental genome (GENOME_PARENT_1) if reads are paired-end.
@@ -147,7 +147,7 @@ rule bismark_alignment_PE_1:
         "../envs/environment.yaml"
     threads: CORES
     shell:
-        "bismark --prefix {params.prefix} --multicore {params.bismark_cores} --genome {params.genome1} -1 {input.fastq1} -2 {input.fastq2} -o {params.output} --temp_dir {params.output} 2>&1 {log}"
+        "bismark --prefix {params.prefix} --multicore {params.bismark_cores} --genome {params.genome1} -1 {input.fastq1} -2 {input.fastq2} -o {params.output} --temp_dir {params.output} 2> {log}"
 
 
 ## Run Bismark to perform alignment to the second parental genome (GENOME_PARENT_2) if reads are paired-end.
@@ -184,4 +184,4 @@ rule bismark_alignment_PE_2:
         "../envs/environment.yaml"
     threads: CORES
     shell:
-        "bismark --prefix {params.prefix} --multicore {params.bismark_cores} --genome {params.genome2} -1 {input.fastq1} -2 {input.fastq2} -o {params.output} --temp_dir {params.output} 2>&1 {log}"
+        "bismark --prefix {params.prefix} --multicore {params.bismark_cores} --genome {params.genome2} -1 {input.fastq1} -2 {input.fastq2} -o {params.output} --temp_dir {params.output} 2> {log}"

--- a/rules/alignment.smk
+++ b/rules/alignment.smk
@@ -18,11 +18,11 @@ rule bismark_prepare_genome_1:
             os.path.split(os.path.split(output.control)[0])[0]
         )[0],
     benchmark:
-        f"{OUTPUT_DIR}benchmark/prepare_genome.txt"
+        f"{OUTPUT_DIR}benchmark/prepare_genome_1.txt"
     conda:
         "../envs/environment.yaml"
     shell:
-        "bismark_genome_preparation {params.genome1}"
+        "bismark_genome_preparation {params.genome1} 2>&1 {log}"
 
 
 ## Run Bismark to prepare synthetic bisulfite converted genomes
@@ -38,11 +38,11 @@ rule bismark_prepare_genome_2:
             os.path.split(os.path.split(output.control)[0])[0]
         )[0],
     benchmark:
-        f"{OUTPUT_DIR}benchmark/prepare_genome.txt"
+        f"{OUTPUT_DIR}benchmark/prepare_genome_2.txt"
     conda:
         "../envs/environment.yaml"
     shell:
-        "bismark_genome_preparation {params.genome2}"
+        "bismark_genome_preparation {params.genome2} 2>&1 {log}"
 
 
 ## Run Bismark to perform alignment to the first parental genome (GENOME_PARENT_1) if reads are single-end.
@@ -76,7 +76,7 @@ rule bismark_alignment_SE_1:
         "../envs/environment.yaml"
     threads: CORES
     shell:
-        "bismark --prefix {params.prefix} --multicore {params.bismark_cores}  -o {params.output} --temp_dir {params.output} --genome {params.genome1} {input.fastq}"
+        "bismark --prefix {params.prefix} --multicore {params.bismark_cores}  -o {params.output} --temp_dir {params.output} --genome {params.genome1} {input.fastq} 2>&1 {log}"
 
 
 ## Run Bismark to perform alignment to the second parental genome (GENOME_PARENT_2) if reads are single-end.
@@ -110,7 +110,7 @@ rule bismark_alignment_SE_2:
         "../envs/environment.yaml"
     threads: CORES
     shell:
-        "bismark --prefix {params.prefix} --multicore {params.bismark_cores}  -o {params.output} --temp_dir {params.output} --genome {params.genome2} {input.fastq}"
+        "bismark --prefix {params.prefix} --multicore {params.bismark_cores}  -o {params.output} --temp_dir {params.output} --genome {params.genome2} {input.fastq} 2>&1 {log}"
 
 
 ## Run Bismark to perform alignment to the first parental genome (GENOME_PARENT_1) if reads are paired-end.
@@ -147,7 +147,7 @@ rule bismark_alignment_PE_1:
         "../envs/environment.yaml"
     threads: CORES
     shell:
-        "bismark --prefix {params.prefix} --multicore {params.bismark_cores} --genome {params.genome1} -1 {input.fastq1} -2 {input.fastq2} -o {params.output} --temp_dir {params.output}"
+        "bismark --prefix {params.prefix} --multicore {params.bismark_cores} --genome {params.genome1} -1 {input.fastq1} -2 {input.fastq2} -o {params.output} --temp_dir {params.output} 2>&1 {log}"
 
 
 ## Run Bismark to perform alignment to the second parental genome (GENOME_PARENT_2) if reads are paired-end.
@@ -184,4 +184,4 @@ rule bismark_alignment_PE_2:
         "../envs/environment.yaml"
     threads: CORES
     shell:
-        "bismark --prefix {params.prefix} --multicore {params.bismark_cores} --genome {params.genome2} -1 {input.fastq1} -2 {input.fastq2} -o {params.output} --temp_dir {params.output}"
+        "bismark --prefix {params.prefix} --multicore {params.bismark_cores} --genome {params.genome2} -1 {input.fastq1} -2 {input.fastq2} -o {params.output} --temp_dir {params.output} 2>&1 {log}"

--- a/rules/build_eagle.smk
+++ b/rules/build_eagle.smk
@@ -59,7 +59,7 @@ rule extract_eagle:
     params:
         build_prefix=lambda w, input: os.path.split(input.eagle_tar)[0],
     log:
-        "{OUTPUT_DIR}logs/extract_eagle.log",
+        f"{OUTPUT_DIR}logs/extract_eagle.log",
     conda:
         ENV_PATH
     shell:
@@ -73,7 +73,7 @@ rule download_htslib:
         htslib_version=HTSLIB_VERSION,
         htslib_tar_name=HTSLIB_TAR_NAME,
     log:
-        "{OUTPUT_DIR}logs/download_htslib.log",
+        f"{OUTPUT_DIR}logs/download_htslib.log",
     conda:
         ENV_PATH
     shell:
@@ -88,7 +88,7 @@ rule extract_htslib:
     params:
         build_prefix=lambda w, input: os.path.split(input.htslib_tar)[0],
     log:
-        "{OUTPUT_DIR}logs/extract_htslib.log",
+        f"{OUTPUT_DIR}logs/extract_htslib.log",
     conda:
         ENV_PATH
     shell:
@@ -106,7 +106,7 @@ rule build_eagle:
         eagle_dir_path=lambda w, input: os.path.split(input.eagle_mk)[0],
         eagle_mk_flags=EAGLE_MK_FLAGS,
     log:
-        "{OUTPUT_DIR}logs/build_eagle.log",
+        f"{OUTPUT_DIR}logs/build_eagle.log",
     conda:
         ENV_PATH
     threads: CORES
@@ -124,7 +124,7 @@ rule install_eagle:
         eagle_dir_path=lambda w, input: os.path.split(input.eagle_bin)[0],
         eagle_mk_flags=EAGLE_MK_FLAGS,
     log:
-        "{OUTPUT_DIR}logs/install_eagle.log",
+        f"{OUTPUT_DIR}logs/install_eagle.log",
     conda:
         ENV_PATH
     shell:

--- a/rules/build_eagle.smk
+++ b/rules/build_eagle.smk
@@ -48,7 +48,7 @@ rule download_eagle:
     conda:
         ENV_PATH
     shell:
-        "wget https://github.com/tony-kuo/eagle/archive/v{params.eagle_version}.tar.gz -O {output.eagle_tar}"
+        "wget https://github.com/tony-kuo/eagle/archive/v{params.eagle_version}.tar.gz -O {output.eagle_tar} 2>&1 {log}"
 
 
 rule extract_eagle:
@@ -63,7 +63,7 @@ rule extract_eagle:
     conda:
         ENV_PATH
     shell:
-        "tar -C {params.build_prefix} -vxf {input.eagle_tar}"
+        "tar -C {params.build_prefix} -vxf {input.eagle_tar} 2>&1 {log}"
 
 
 rule download_htslib:
@@ -77,7 +77,7 @@ rule download_htslib:
     conda:
         ENV_PATH
     shell:
-        "wget https://github.com/samtools/htslib/releases/download/{params.htslib_version}/{params.htslib_tar_name} -O {output.htslib_tar}"
+        "wget https://github.com/samtools/htslib/releases/download/{params.htslib_version}/{params.htslib_tar_name} -O {output.htslib_tar} 2>&1 {log}"
 
 
 rule extract_htslib:
@@ -92,7 +92,7 @@ rule extract_htslib:
     conda:
         ENV_PATH
     shell:
-        "tar -C {params.build_prefix} -vxf {input.htslib_tar}"
+        "tar -C {params.build_prefix} -vxf {input.htslib_tar} 2>&1 {log}"
 
 
 rule build_eagle:
@@ -111,7 +111,7 @@ rule build_eagle:
         ENV_PATH
     threads: CORES
     shell:
-        "{params.eagle_mk_env} make -j {threads} -C {params.eagle_dir_path} {params.eagle_mk_flags}"
+        "{params.eagle_mk_env} make -j {threads} -C {params.eagle_dir_path} {params.eagle_mk_flags} 2>&1 {log}"
 
 
 rule install_eagle:
@@ -128,4 +128,4 @@ rule install_eagle:
     conda:
         ENV_PATH
     shell:
-        "{params.eagle_mk_env} make -C {params.eagle_dir_path} install {params.eagle_mk_flags}"
+        "{params.eagle_mk_env} make -C {params.eagle_dir_path} install {params.eagle_mk_flags} 2>&1 {log}"

--- a/rules/build_eagle.smk
+++ b/rules/build_eagle.smk
@@ -44,7 +44,7 @@ rule download_eagle:
     params:
         eagle_version=EAGLE_VERSION,
     log:
-        "{OUTPUT_DIR}logs/download_eagle.log",
+        f"{OUTPUT_DIR}logs/download_eagle.log",
     conda:
         ENV_PATH
     shell:

--- a/rules/build_eagle.smk
+++ b/rules/build_eagle.smk
@@ -44,7 +44,7 @@ rule download_eagle:
     params:
         eagle_version=EAGLE_VERSION,
     log:
-        "logs/download_eagle.log",
+        "{OUTPUT_DIR}logs/download_eagle.log",
     conda:
         ENV_PATH
     shell:
@@ -59,7 +59,7 @@ rule extract_eagle:
     params:
         build_prefix=lambda w, input: os.path.split(input.eagle_tar)[0],
     log:
-        "logs/extract_eagle.log",
+        "{OUTPUT_DIR}logs/extract_eagle.log",
     conda:
         ENV_PATH
     shell:
@@ -73,7 +73,7 @@ rule download_htslib:
         htslib_version=HTSLIB_VERSION,
         htslib_tar_name=HTSLIB_TAR_NAME,
     log:
-        "logs/download_htslib.log",
+        "{OUTPUT_DIR}logs/download_htslib.log",
     conda:
         ENV_PATH
     shell:
@@ -88,7 +88,7 @@ rule extract_htslib:
     params:
         build_prefix=lambda w, input: os.path.split(input.htslib_tar)[0],
     log:
-        "logs/extract_htslib.log",
+        "{OUTPUT_DIR}logs/extract_htslib.log",
     conda:
         ENV_PATH
     shell:
@@ -106,7 +106,7 @@ rule build_eagle:
         eagle_dir_path=lambda w, input: os.path.split(input.eagle_mk)[0],
         eagle_mk_flags=EAGLE_MK_FLAGS,
     log:
-        "logs/build_eagle.log",
+        "{OUTPUT_DIR}logs/build_eagle.log",
     conda:
         ENV_PATH
     threads: CORES
@@ -124,7 +124,7 @@ rule install_eagle:
         eagle_dir_path=lambda w, input: os.path.split(input.eagle_bin)[0],
         eagle_mk_flags=EAGLE_MK_FLAGS,
     log:
-        "logs/install_eagle.log",
+        "{OUTPUT_DIR}logs/install_eagle.log",
     conda:
         ENV_PATH
     shell:

--- a/rules/build_eagle.smk
+++ b/rules/build_eagle.smk
@@ -48,7 +48,7 @@ rule download_eagle:
     conda:
         ENV_PATH
     shell:
-        "wget https://github.com/tony-kuo/eagle/archive/v{params.eagle_version}.tar.gz -O {output.eagle_tar} 2>&1 {log}"
+        "wget https://github.com/tony-kuo/eagle/archive/v{params.eagle_version}.tar.gz -O {output.eagle_tar} 2> {log}"
 
 
 rule extract_eagle:
@@ -63,7 +63,7 @@ rule extract_eagle:
     conda:
         ENV_PATH
     shell:
-        "tar -C {params.build_prefix} -vxf {input.eagle_tar} 2>&1 {log}"
+        "tar -C {params.build_prefix} -vxf {input.eagle_tar} 2> {log}"
 
 
 rule download_htslib:
@@ -77,7 +77,7 @@ rule download_htslib:
     conda:
         ENV_PATH
     shell:
-        "wget https://github.com/samtools/htslib/releases/download/{params.htslib_version}/{params.htslib_tar_name} -O {output.htslib_tar} 2>&1 {log}"
+        "wget https://github.com/samtools/htslib/releases/download/{params.htslib_version}/{params.htslib_tar_name} -O {output.htslib_tar} 2> {log}"
 
 
 rule extract_htslib:
@@ -92,7 +92,7 @@ rule extract_htslib:
     conda:
         ENV_PATH
     shell:
-        "tar -C {params.build_prefix} -vxf {input.htslib_tar} 2>&1 {log}"
+        "tar -C {params.build_prefix} -vxf {input.htslib_tar} 2> {log}"
 
 
 rule build_eagle:
@@ -111,7 +111,7 @@ rule build_eagle:
         ENV_PATH
     threads: CORES
     shell:
-        "{params.eagle_mk_env} make -j {threads} -C {params.eagle_dir_path} {params.eagle_mk_flags} 2>&1 {log}"
+        "{params.eagle_mk_env} make -j {threads} -C {params.eagle_dir_path} {params.eagle_mk_flags} 2> {log}"
 
 
 rule install_eagle:
@@ -128,4 +128,4 @@ rule install_eagle:
     conda:
         ENV_PATH
     shell:
-        "{params.eagle_mk_env} make -C {params.eagle_dir_path} install {params.eagle_mk_flags} 2>&1 {log}"
+        "{params.eagle_mk_env} make -C {params.eagle_dir_path} install {params.eagle_mk_flags} 2> {log}"

--- a/rules/deduplication.smk
+++ b/rules/deduplication.smk
@@ -26,7 +26,7 @@ rule deduplication_SE:
     conda:
         "../envs/environment.yaml"
     shell:
-        "deduplicate_bismark -s --output_dir {params} --bam {input}"
+        "deduplicate_bismark -s --output_dir {params} --bam {input} 2>&1 {log}"
 
 
 ## Run deduplication of the alignments to remove duplicated reads for PE reads (GENOME_PARENT_1)
@@ -50,4 +50,4 @@ rule deduplication_PE:
     conda:
         "../envs/environment.yaml"
     shell:
-        "deduplicate_bismark -p --output_dir {params} --bam {input}"
+        "deduplicate_bismark -p --output_dir {params} --bam {input} 2>&1 {log}"

--- a/rules/deduplication.smk
+++ b/rules/deduplication.smk
@@ -18,7 +18,7 @@ rule deduplication_SE:
         if config["RUN_TRIMMING"]
         else f"{OUTPUT_DIR}Bismark/deduplication/{{sample}}_{{one_or_two}}/{{one_or_two}}.{{sample}}_bismark_bt2.deduplicated.bam",
     log:
-        f"logs/deduplication_{{sample}}_{{one_or_two}}_SE.log",
+        f"{OUTPUT_DIR}logs/deduplication_{{sample}}_{{one_or_two}}_SE.log",
     params:
         f"{OUTPUT_DIR}Bismark/deduplication/{{sample}}_{{one_or_two}}/",
     benchmark:
@@ -42,7 +42,7 @@ rule deduplication_PE:
         if config["RUN_TRIMMING"]
         else f"{OUTPUT_DIR}Bismark/deduplication/{{sample}}_{{one_or_two}}/{{one_or_two}}.{{sample}}_{str(config['PAIR_1'])}_bismark_bt2_pe.deduplicated.bam",
     log:
-        f"logs/deduplication_{{sample}}_{{one_or_two}}_PE.log",
+        f"{OUTPUT_DIR}logs/deduplication_{{sample}}_{{one_or_two}}_PE.log",
     params:
         f"{OUTPUT_DIR}Bismark/deduplication/{{sample}}_{{one_or_two}}/",
     benchmark:

--- a/rules/deduplication.smk
+++ b/rules/deduplication.smk
@@ -26,7 +26,7 @@ rule deduplication_SE:
     conda:
         "../envs/environment.yaml"
     shell:
-        "deduplicate_bismark -s --output_dir {params} --bam {input} 2>&1 {log}"
+        "deduplicate_bismark -s --output_dir {params} --bam {input} 2> {log}"
 
 
 ## Run deduplication of the alignments to remove duplicated reads for PE reads (GENOME_PARENT_1)
@@ -50,4 +50,4 @@ rule deduplication_PE:
     conda:
         "../envs/environment.yaml"
     shell:
-        "deduplicate_bismark -p --output_dir {params} --bam {input} 2>&1 {log}"
+        "deduplicate_bismark -p --output_dir {params} --bam {input} 2> {log}"

--- a/rules/differential_methylation_analysis.smk
+++ b/rules/differential_methylation_analysis.smk
@@ -17,14 +17,14 @@ rule context_separation_parent_1:
         o2=f"{OUTPUT_DIR}DMR_analysis/context_separation/parent1/{{sample}}_CHG.cov",
         o3=f"{OUTPUT_DIR}DMR_analysis/context_separation/parent1/{{sample}}_CHH.cov",
     log:
-        f"logs/context_separation_{{sample}}_p1.log",
+        f"{OUTPUT_DIR}/logs/context_separation_{{sample}}_p1.log",
     params:
         sample_name=f"{{sample}}",
         output=lambda w, output: os.path.split(output.o1)[0],
     conda:
         "../envs/environment_downstream.yaml"
     shell:
-        "Rscript scripts/CoverageFileGeneratorComplete.R {input.p1} {params.output} {params.sample_name}"
+        "Rscript scripts/CoverageFileGeneratorComplete.R {input.p1} {params.output} {params.sample_name} 2>&1 {log}"
 
 
 ## Run R script to remove all rows with no cytosines and generate three files for each cytosine context for parent 2
@@ -38,14 +38,14 @@ rule context_separation_parent_2:
         o2=f"{OUTPUT_DIR}DMR_analysis/context_separation/parent2/{{sample}}_CHG.cov",
         o3=f"{OUTPUT_DIR}DMR_analysis/context_separation/parent2/{{sample}}_CHH.cov",
     log:
-        f"logs/context_separation_{{sample}}_p2.log",
+        f"{OUTPUT_DIR}/logs/context_separation_{{sample}}_p2.log",
     params:
         sample_name=f"{{sample}}",
         output=lambda w, output: os.path.split(output.o1)[0],
     conda:
         "../envs/environment_downstream.yaml"
     shell:
-        "Rscript scripts/CoverageFileGeneratorComplete.R {input.p1} {params.output} {params.sample_name}"
+        "Rscript scripts/CoverageFileGeneratorComplete.R {input.p1} {params.output} {params.sample_name} 2>&1 {log}"
 
 
 ## Run R script to remove all rows with no cytosines and generate three files for each cytosine context for parent 1
@@ -58,7 +58,7 @@ rule combine_context_allo:
     output:
         f"{OUTPUT_DIR}Bismark/extraction/{{sample}}_12/{{sample}}.CX_report.txt",
     log:
-        f"logs/combine_context_{{sample}}_12.log",
+        f"{OUTPUT_DIR}/logs/combine_context_{{sample}}_12.log",
     shell:
         "cat {input.p1} {input.p2} > {output}"
 
@@ -71,14 +71,14 @@ rule context_separation_allo:
         o2=f"{OUTPUT_DIR}DMR_analysis/context_separation/allopolyploid/{{sample}}_CHG.cov",
         o3=f"{OUTPUT_DIR}DMR_analysis/context_separation/allopolyploid/{{sample}}_CHH.cov",
     log:
-        f"logs/context_separation_{{sample}}_allo.log",
+        f"{OUTPUT_DIR}/logs/context_separation_{{sample}}_allo.log",
     params:
         sample_name=f"{{sample}}",
         output=lambda w, output: os.path.split(output.o1)[0],
     conda:
         "../envs/environment_downstream.yaml"
     shell:
-        "Rscript scripts/CoverageFileGeneratorComplete.R {input} {params.output} {params.sample_name}"
+        "Rscript scripts/CoverageFileGeneratorComplete.R {input} {params.output} {params.sample_name} 2>&1 {log}"
 
 
 # Run dmrseq for CG context for parent1 subgenome
@@ -91,7 +91,7 @@ rule dmrseq_CG_1:
     output:
         comparison1=f"{OUTPUT_DIR}DMR_analysis/dmrseq/CG_context/parent1_v_allo.txt",
     log:
-        f"logs/dmrseq_CG_1.log",
+        f"{OUTPUT_DIR}/logs/dmrseq_CG_1.log",
     benchmark:
         f"{OUTPUT_DIR}benchmark/dmrseq_CG.txt"
     params:
@@ -102,7 +102,7 @@ rule dmrseq_CG_1:
     conda:
         "../envs/environment_R.yaml"
     shell:
-        "Rscript scripts/dmrseq.R {params.n_samples_p1} {params.n_samples_allo} {output.comparison1} {threads} {input.p1} {input.allo}"
+        "Rscript scripts/dmrseq.R {params.n_samples_p1} {params.n_samples_allo} {output.comparison1} {threads} {input.p1} {input.allo} 2>&1 {log}"
 
 
 # Run dmrseq for CG context for parent2 subgenome
@@ -115,7 +115,7 @@ rule dmrseq_CG_2:
     output:
         comparison2=f"{OUTPUT_DIR}DMR_analysis/dmrseq/CG_context/parent2_v_allo.txt",
     log:
-        f"logs/dmrseq_CG_2.log",
+        f"{OUTPUT_DIR}/logs/dmrseq_CG_2.log",
     benchmark:
         f"{OUTPUT_DIR}benchmark/dmrseq_CG.txt"
     params:
@@ -126,7 +126,7 @@ rule dmrseq_CG_2:
     conda:
         "../envs/environment_R.yaml"
     shell:
-        "Rscript scripts/dmrseq.R {params.n_samples_p2} {params.n_samples_allo} {output.comparison2} {threads} {input.p2} {input.allo}"
+        "Rscript scripts/dmrseq.R {params.n_samples_p2} {params.n_samples_allo} {output.comparison2} {threads} {input.p2} {input.allo} 2>&1 {log}"
 
 
 # Run dmrseq for CHG context for parent1 subgenome
@@ -139,7 +139,7 @@ rule dmrseq_CHG_1:
     output:
         comparison1=f"{OUTPUT_DIR}DMR_analysis/dmrseq/CHG_context/parent1_v_allo.txt",
     log:
-        f"logs/dmrseq_CHG_1.log",
+        f"{OUTPUT_DIR}/logs/dmrseq_CHG_1.log",
     benchmark:
         f"{OUTPUT_DIR}benchmark/dmrseq_CHG.txt"
     params:
@@ -150,7 +150,7 @@ rule dmrseq_CHG_1:
     conda:
         "../envs/environment_R.yaml"
     shell:
-        "Rscript scripts/dmrseq.R {params.n_samples_p1} {params.n_samples_allo} {output.comparison1} {threads} {input.p1} {input.allo}"
+        "Rscript scripts/dmrseq.R {params.n_samples_p1} {params.n_samples_allo} {output.comparison1} {threads} {input.p1} {input.allo} 2>&1 {log}"
 
 
 # Run dmrseq for CHG context for parent2 subgenome
@@ -163,7 +163,7 @@ rule dmrseq_CHG_2:
     output:
         comparison2=f"{OUTPUT_DIR}DMR_analysis/dmrseq/CHG_context/parent2_v_allo.txt",
     log:
-        f"logs/dmrseq_CHG_2.log",
+        f"{OUTPUT_DIR}/logs/dmrseq_CHG_2.log",
     benchmark:
         f"{OUTPUT_DIR}benchmark/dmrseq_CHG.txt"
     params:
@@ -174,7 +174,7 @@ rule dmrseq_CHG_2:
     conda:
         "../envs/environment_R.yaml"
     shell:
-        "Rscript scripts/dmrseq.R {params.n_samples_p2} {params.n_samples_allo} {output.comparison2} {threads} {input.p2} {input.allo}"
+        "Rscript scripts/dmrseq.R {params.n_samples_p2} {params.n_samples_allo} {output.comparison2} {threads} {input.p2} {input.allo} 2>&1 {log}"
 
 
 # Run dmrseq for CHH context for parent1 subgenome
@@ -187,7 +187,7 @@ rule dmrseq_CHH_1:
     output:
         comparison1=f"{OUTPUT_DIR}DMR_analysis/dmrseq/CHH_context/parent1_v_allo.txt",
     log:
-        f"logs/dmrseq_CHH_1.log",
+        f"{OUTPUT_DIR}/logs/dmrseq_CHH_1.log",
     benchmark:
         f"{OUTPUT_DIR}benchmark/dmrseq_CHH.txt"
     params:
@@ -198,7 +198,7 @@ rule dmrseq_CHH_1:
     conda:
         "../envs/environment_R.yaml"
     shell:
-        "Rscript scripts/dmrseq.R {params.n_samples_p1} {params.n_samples_allo} {output.comparison1} {threads} {input.p1} {input.allo}"
+        "Rscript scripts/dmrseq.R {params.n_samples_p1} {params.n_samples_allo} {output.comparison1} {threads} {input.p1} {input.allo} 2>&1 {log}"
 
 
 # Run dmrseq for CHH context for parent2 subgenome
@@ -211,7 +211,7 @@ rule dmrseq_CHH_2:
     output:
         comparison2=f"{OUTPUT_DIR}DMR_analysis/dmrseq/CHH_context/parent2_v_allo.txt",
     log:
-        f"logs/dmrseq_CHH_2.log",
+        f"{OUTPUT_DIR}/logs/dmrseq_CHH_2.log",
     benchmark:
         f"{OUTPUT_DIR}benchmark/dmrseq_CHH.txt"
     params:
@@ -222,7 +222,7 @@ rule dmrseq_CHH_2:
     conda:
         "../envs/environment_R.yaml"
     shell:
-        "Rscript scripts/dmrseq.R {params.n_samples_p2} {params.n_samples_allo} {output.comparison2} {threads} {input.p2} {input.allo}"
+        "Rscript scripts/dmrseq.R {params.n_samples_p2} {params.n_samples_allo} {output.comparison2} {threads} {input.p2} {input.allo} 2>&1 {log}"
 
 
 ## Rules for dmrseq comparing polyploids to polyploids or diploids to diploids based on conditions given in the metadata file
@@ -237,7 +237,7 @@ rule dmrseq_CG_special:
         if config["DIPLOID_ONLY"]
         else f"{OUTPUT_DIR}DMR_analysis/dmrseq/CG_context/A_v_B_polyploid.txt",
     log:
-        f"logs/dmrseq_CG_special.log",
+        f"{OUTPUT_DIR}/logs/dmrseq_CG_special.log",
     benchmark:
         f"{OUTPUT_DIR}benchmark/dmrseq_CG_special.txt"
     params:
@@ -247,7 +247,7 @@ rule dmrseq_CG_special:
     conda:
         "../envs/environment_R.yaml"
     shell:
-        "Rscript scripts/dmrseq.R {params.samples_B} {params.samples_A} {output.comparison} {threads} {input.condB} {input.condA}"
+        "Rscript scripts/dmrseq.R {params.samples_B} {params.samples_A} {output.comparison} {threads} {input.condB} {input.condA} 2>&1 {log}"
 
 
 rule dmrseq_CHG_special:
@@ -259,7 +259,7 @@ rule dmrseq_CHG_special:
         if config["DIPLOID_ONLY"]
         else f"{OUTPUT_DIR}DMR_analysis/dmrseq/CHG_context/A_v_B_polyploid.txt",
     log:
-        f"logs/dmrseq_CHG_special.log",
+        f"{OUTPUT_DIR}/logs/dmrseq_CHG_special.log",
     benchmark:
         f"{OUTPUT_DIR}benchmark/dmrseq_CHG_special.txt"
     params:
@@ -269,7 +269,7 @@ rule dmrseq_CHG_special:
     conda:
         "../envs/environment_R.yaml"
     shell:
-        "Rscript scripts/dmrseq.R {params.samples_B} {params.samples_A} {output.comparison} {threads} {input.condB} {input.condA}"
+        "Rscript scripts/dmrseq.R {params.samples_B} {params.samples_A} {output.comparison} {threads} {input.condB} {input.condA} 2>&1 {log}"
 
 
 rule dmrseq_CHH_special:
@@ -281,7 +281,7 @@ rule dmrseq_CHH_special:
         if config["DIPLOID_ONLY"]
         else f"{OUTPUT_DIR}DMR_analysis/dmrseq/CHH_context/A_v_B_polyploid.txt",
     log:
-        f"logs/dmrseq_CHH_special.log",
+        f"{OUTPUT_DIR}/logs/dmrseq_CHH_special.log",
     benchmark:
         f"{OUTPUT_DIR}benchmark/dmrseq_CHH_special.txt"
     params:
@@ -291,4 +291,4 @@ rule dmrseq_CHH_special:
     conda:
         "../envs/environment_R.yaml"
     shell:
-        "Rscript scripts/dmrseq.R {params.samples_B} {params.samples_A} {output.comparison} {threads} {input.condB} {input.condA}"
+        "Rscript scripts/dmrseq.R {params.samples_B} {params.samples_A} {output.comparison} {threads} {input.condB} {input.condA} 2>&1 {log}"

--- a/rules/differential_methylation_analysis.smk
+++ b/rules/differential_methylation_analysis.smk
@@ -17,7 +17,7 @@ rule context_separation_parent_1:
         o2=f"{OUTPUT_DIR}DMR_analysis/context_separation/parent1/{{sample}}_CHG.cov",
         o3=f"{OUTPUT_DIR}DMR_analysis/context_separation/parent1/{{sample}}_CHH.cov",
     log:
-        f"{OUTPUT_DIR}/logs/context_separation_{{sample}}_p1.log",
+        f"{OUTPUT_DIR}logs/context_separation_{{sample}}_p1.log",
     params:
         sample_name=f"{{sample}}",
         output=lambda w, output: os.path.split(output.o1)[0],
@@ -38,7 +38,7 @@ rule context_separation_parent_2:
         o2=f"{OUTPUT_DIR}DMR_analysis/context_separation/parent2/{{sample}}_CHG.cov",
         o3=f"{OUTPUT_DIR}DMR_analysis/context_separation/parent2/{{sample}}_CHH.cov",
     log:
-        f"{OUTPUT_DIR}/logs/context_separation_{{sample}}_p2.log",
+        f"{OUTPUT_DIR}logs/context_separation_{{sample}}_p2.log",
     params:
         sample_name=f"{{sample}}",
         output=lambda w, output: os.path.split(output.o1)[0],
@@ -58,7 +58,7 @@ rule combine_context_allo:
     output:
         f"{OUTPUT_DIR}Bismark/extraction/{{sample}}_12/{{sample}}.CX_report.txt",
     log:
-        f"{OUTPUT_DIR}/logs/combine_context_{{sample}}_12.log",
+        f"{OUTPUT_DIR}logs/combine_context_{{sample}}_12.log",
     shell:
         "cat {input.p1} {input.p2} > {output}"
 
@@ -71,7 +71,7 @@ rule context_separation_allo:
         o2=f"{OUTPUT_DIR}DMR_analysis/context_separation/allopolyploid/{{sample}}_CHG.cov",
         o3=f"{OUTPUT_DIR}DMR_analysis/context_separation/allopolyploid/{{sample}}_CHH.cov",
     log:
-        f"{OUTPUT_DIR}/logs/context_separation_{{sample}}_allo.log",
+        f"{OUTPUT_DIR}logs/context_separation_{{sample}}_allo.log",
     params:
         sample_name=f"{{sample}}",
         output=lambda w, output: os.path.split(output.o1)[0],
@@ -91,7 +91,7 @@ rule dmrseq_CG_1:
     output:
         comparison1=f"{OUTPUT_DIR}DMR_analysis/dmrseq/CG_context/parent1_v_allo.txt",
     log:
-        f"{OUTPUT_DIR}/logs/dmrseq_CG_1.log",
+        f"{OUTPUT_DIR}logs/dmrseq_CG_1.log",
     benchmark:
         f"{OUTPUT_DIR}benchmark/dmrseq_CG.txt"
     params:
@@ -115,7 +115,7 @@ rule dmrseq_CG_2:
     output:
         comparison2=f"{OUTPUT_DIR}DMR_analysis/dmrseq/CG_context/parent2_v_allo.txt",
     log:
-        f"{OUTPUT_DIR}/logs/dmrseq_CG_2.log",
+        f"{OUTPUT_DIR}logs/dmrseq_CG_2.log",
     benchmark:
         f"{OUTPUT_DIR}benchmark/dmrseq_CG.txt"
     params:
@@ -139,7 +139,7 @@ rule dmrseq_CHG_1:
     output:
         comparison1=f"{OUTPUT_DIR}DMR_analysis/dmrseq/CHG_context/parent1_v_allo.txt",
     log:
-        f"{OUTPUT_DIR}/logs/dmrseq_CHG_1.log",
+        f"{OUTPUT_DIR}logs/dmrseq_CHG_1.log",
     benchmark:
         f"{OUTPUT_DIR}benchmark/dmrseq_CHG.txt"
     params:
@@ -163,7 +163,7 @@ rule dmrseq_CHG_2:
     output:
         comparison2=f"{OUTPUT_DIR}DMR_analysis/dmrseq/CHG_context/parent2_v_allo.txt",
     log:
-        f"{OUTPUT_DIR}/logs/dmrseq_CHG_2.log",
+        f"{OUTPUT_DIR}logs/dmrseq_CHG_2.log",
     benchmark:
         f"{OUTPUT_DIR}benchmark/dmrseq_CHG.txt"
     params:
@@ -187,7 +187,7 @@ rule dmrseq_CHH_1:
     output:
         comparison1=f"{OUTPUT_DIR}DMR_analysis/dmrseq/CHH_context/parent1_v_allo.txt",
     log:
-        f"{OUTPUT_DIR}/logs/dmrseq_CHH_1.log",
+        f"{OUTPUT_DIR}logs/dmrseq_CHH_1.log",
     benchmark:
         f"{OUTPUT_DIR}benchmark/dmrseq_CHH.txt"
     params:
@@ -211,7 +211,7 @@ rule dmrseq_CHH_2:
     output:
         comparison2=f"{OUTPUT_DIR}DMR_analysis/dmrseq/CHH_context/parent2_v_allo.txt",
     log:
-        f"{OUTPUT_DIR}/logs/dmrseq_CHH_2.log",
+        f"{OUTPUT_DIR}logs/dmrseq_CHH_2.log",
     benchmark:
         f"{OUTPUT_DIR}benchmark/dmrseq_CHH.txt"
     params:
@@ -237,7 +237,7 @@ rule dmrseq_CG_special:
         if config["DIPLOID_ONLY"]
         else f"{OUTPUT_DIR}DMR_analysis/dmrseq/CG_context/A_v_B_polyploid.txt",
     log:
-        f"{OUTPUT_DIR}/logs/dmrseq_CG_special.log",
+        f"{OUTPUT_DIR}logs/dmrseq_CG_special.log",
     benchmark:
         f"{OUTPUT_DIR}benchmark/dmrseq_CG_special.txt"
     params:
@@ -259,7 +259,7 @@ rule dmrseq_CHG_special:
         if config["DIPLOID_ONLY"]
         else f"{OUTPUT_DIR}DMR_analysis/dmrseq/CHG_context/A_v_B_polyploid.txt",
     log:
-        f"{OUTPUT_DIR}/logs/dmrseq_CHG_special.log",
+        f"{OUTPUT_DIR}logs/dmrseq_CHG_special.log",
     benchmark:
         f"{OUTPUT_DIR}benchmark/dmrseq_CHG_special.txt"
     params:
@@ -281,7 +281,7 @@ rule dmrseq_CHH_special:
         if config["DIPLOID_ONLY"]
         else f"{OUTPUT_DIR}DMR_analysis/dmrseq/CHH_context/A_v_B_polyploid.txt",
     log:
-        f"{OUTPUT_DIR}/logs/dmrseq_CHH_special.log",
+        f"{OUTPUT_DIR}logs/dmrseq_CHH_special.log",
     benchmark:
         f"{OUTPUT_DIR}benchmark/dmrseq_CHH_special.txt"
     params:

--- a/rules/differential_methylation_analysis.smk
+++ b/rules/differential_methylation_analysis.smk
@@ -24,7 +24,7 @@ rule context_separation_parent_1:
     conda:
         "../envs/environment_downstream.yaml"
     shell:
-        "Rscript scripts/CoverageFileGeneratorComplete.R {input.p1} {params.output} {params.sample_name} 2>&1 {log}"
+        "Rscript scripts/CoverageFileGeneratorComplete.R {input.p1} {params.output} {params.sample_name} 2> {log}"
 
 
 ## Run R script to remove all rows with no cytosines and generate three files for each cytosine context for parent 2
@@ -45,7 +45,7 @@ rule context_separation_parent_2:
     conda:
         "../envs/environment_downstream.yaml"
     shell:
-        "Rscript scripts/CoverageFileGeneratorComplete.R {input.p1} {params.output} {params.sample_name} 2>&1 {log}"
+        "Rscript scripts/CoverageFileGeneratorComplete.R {input.p1} {params.output} {params.sample_name} 2> {log}"
 
 
 ## Run R script to remove all rows with no cytosines and generate three files for each cytosine context for parent 1
@@ -78,7 +78,7 @@ rule context_separation_allo:
     conda:
         "../envs/environment_downstream.yaml"
     shell:
-        "Rscript scripts/CoverageFileGeneratorComplete.R {input} {params.output} {params.sample_name} 2>&1 {log}"
+        "Rscript scripts/CoverageFileGeneratorComplete.R {input} {params.output} {params.sample_name} 2> {log}"
 
 
 # Run dmrseq for CG context for parent1 subgenome
@@ -102,7 +102,7 @@ rule dmrseq_CG_1:
     conda:
         "../envs/environment_R.yaml"
     shell:
-        "Rscript scripts/dmrseq.R {params.n_samples_p1} {params.n_samples_allo} {output.comparison1} {threads} {input.p1} {input.allo} 2>&1 {log}"
+        "Rscript scripts/dmrseq.R {params.n_samples_p1} {params.n_samples_allo} {output.comparison1} {threads} {input.p1} {input.allo} 2> {log}"
 
 
 # Run dmrseq for CG context for parent2 subgenome
@@ -126,7 +126,7 @@ rule dmrseq_CG_2:
     conda:
         "../envs/environment_R.yaml"
     shell:
-        "Rscript scripts/dmrseq.R {params.n_samples_p2} {params.n_samples_allo} {output.comparison2} {threads} {input.p2} {input.allo} 2>&1 {log}"
+        "Rscript scripts/dmrseq.R {params.n_samples_p2} {params.n_samples_allo} {output.comparison2} {threads} {input.p2} {input.allo} 2> {log}"
 
 
 # Run dmrseq for CHG context for parent1 subgenome
@@ -150,7 +150,7 @@ rule dmrseq_CHG_1:
     conda:
         "../envs/environment_R.yaml"
     shell:
-        "Rscript scripts/dmrseq.R {params.n_samples_p1} {params.n_samples_allo} {output.comparison1} {threads} {input.p1} {input.allo} 2>&1 {log}"
+        "Rscript scripts/dmrseq.R {params.n_samples_p1} {params.n_samples_allo} {output.comparison1} {threads} {input.p1} {input.allo} 2> {log}"
 
 
 # Run dmrseq for CHG context for parent2 subgenome
@@ -174,7 +174,7 @@ rule dmrseq_CHG_2:
     conda:
         "../envs/environment_R.yaml"
     shell:
-        "Rscript scripts/dmrseq.R {params.n_samples_p2} {params.n_samples_allo} {output.comparison2} {threads} {input.p2} {input.allo} 2>&1 {log}"
+        "Rscript scripts/dmrseq.R {params.n_samples_p2} {params.n_samples_allo} {output.comparison2} {threads} {input.p2} {input.allo} 2> {log}"
 
 
 # Run dmrseq for CHH context for parent1 subgenome
@@ -198,7 +198,7 @@ rule dmrseq_CHH_1:
     conda:
         "../envs/environment_R.yaml"
     shell:
-        "Rscript scripts/dmrseq.R {params.n_samples_p1} {params.n_samples_allo} {output.comparison1} {threads} {input.p1} {input.allo} 2>&1 {log}"
+        "Rscript scripts/dmrseq.R {params.n_samples_p1} {params.n_samples_allo} {output.comparison1} {threads} {input.p1} {input.allo} 2> {log}"
 
 
 # Run dmrseq for CHH context for parent2 subgenome
@@ -222,7 +222,7 @@ rule dmrseq_CHH_2:
     conda:
         "../envs/environment_R.yaml"
     shell:
-        "Rscript scripts/dmrseq.R {params.n_samples_p2} {params.n_samples_allo} {output.comparison2} {threads} {input.p2} {input.allo} 2>&1 {log}"
+        "Rscript scripts/dmrseq.R {params.n_samples_p2} {params.n_samples_allo} {output.comparison2} {threads} {input.p2} {input.allo} 2> {log}"
 
 
 ## Rules for dmrseq comparing polyploids to polyploids or diploids to diploids based on conditions given in the metadata file
@@ -247,7 +247,7 @@ rule dmrseq_CG_special:
     conda:
         "../envs/environment_R.yaml"
     shell:
-        "Rscript scripts/dmrseq.R {params.samples_B} {params.samples_A} {output.comparison} {threads} {input.condB} {input.condA} 2>&1 {log}"
+        "Rscript scripts/dmrseq.R {params.samples_B} {params.samples_A} {output.comparison} {threads} {input.condB} {input.condA} 2> {log}"
 
 
 rule dmrseq_CHG_special:
@@ -269,7 +269,7 @@ rule dmrseq_CHG_special:
     conda:
         "../envs/environment_R.yaml"
     shell:
-        "Rscript scripts/dmrseq.R {params.samples_B} {params.samples_A} {output.comparison} {threads} {input.condB} {input.condA} 2>&1 {log}"
+        "Rscript scripts/dmrseq.R {params.samples_B} {params.samples_A} {output.comparison} {threads} {input.condB} {input.condA} 2> {log}"
 
 
 rule dmrseq_CHH_special:
@@ -291,4 +291,4 @@ rule dmrseq_CHH_special:
     conda:
         "../envs/environment_R.yaml"
     shell:
-        "Rscript scripts/dmrseq.R {params.samples_B} {params.samples_A} {output.comparison} {threads} {input.condB} {input.condA} 2>&1 {log}"
+        "Rscript scripts/dmrseq.R {params.samples_B} {params.samples_A} {output.comparison} {threads} {input.condB} {input.condA} 2> {log}"

--- a/rules/downstream.smk
+++ b/rules/downstream.smk
@@ -21,7 +21,7 @@ rule dm_regions_bed:
     conda:
         "../envs/environment_downstream.yaml"
     shell:
-        "Rscript scripts/significantGenesToBed.R {input} {params} 2>&1 {log}"
+        "Rscript scripts/significantGenesToBed.R {input} {params} 2> {log}"
 
 
 # The first downstream rule for special mode: diploid vs diploid or polyploid vs polyploid. Read above for a short explanation of the rule.
@@ -47,7 +47,7 @@ rule dm_regions_bed_special:
     conda:
         "../envs/environment_downstream.yaml"
     shell:
-        "Rscript scripts/significantGenesToBed.R {input} {params} 2>&1 {log}"
+        "Rscript scripts/significantGenesToBed.R {input} {params} 2> {log}"
 
 
 # The second downsteam rule checks the gene regions provided in the annotation file and finds any overlaps with DMRs. The output includes all genes showing an overlap with the overlapping DMR.
@@ -67,7 +67,7 @@ rule bedtools_intersect_1:
     conda:
         "../envs/environment_downstream.yaml"
     shell:
-        "bedtools intersect -a {params.anno1} -b {input.i1} -wo > {output.o1} 2>&1 {log}"
+        "bedtools intersect -a {params.anno1} -b {input.i1} -wo > {output.o1} 2> {log}"
 
 
 rule bedtools_intersect_2:
@@ -84,7 +84,7 @@ rule bedtools_intersect_2:
     conda:
         "../envs/environment_downstream.yaml"
     shell:
-        "bedtools intersect -a {params.anno2} -b {input.i2} -wo > {output.o2} 2>&1 {log}"
+        "bedtools intersect -a {params.anno2} -b {input.i2} -wo > {output.o2} 2> {log}"
 
 
 # The second downstream rule for special mode: diploid vs diploid or polyploid vs polyploid. Read above for a short explanation of the rule.
@@ -103,9 +103,9 @@ rule bedtools_intersect_special_diploid:
     conda:
         "../envs/environment_downstream.yaml"
     shell:
-        "bedtools intersect -a {params.anno1} -b {input} -wo > {output} 2>&1 {log}" if (
+        "bedtools intersect -a {params.anno1} -b {input} -wo > {output} 2> {log}" if (
         sum(samples.origin == "parent1") > 0
-        ) else "bedtools intersect -a {params.anno2} -b {input} -wo > {output} 2>&1 {log}"
+        ) else "bedtools intersect -a {params.anno2} -b {input} -wo > {output} 2> {log}"
 
 
 rule bedtools_intersect_special_polyploid_1:
@@ -120,7 +120,7 @@ rule bedtools_intersect_special_polyploid_1:
     conda:
         "../envs/environment_downstream.yaml"
     shell:
-        "bedtools intersect -a {params.anno1} -b {input} -wo > {output} 2>&1 {log}"
+        "bedtools intersect -a {params.anno1} -b {input} -wo > {output} 2> {log}"
 
 
 rule bedtools_intersect_special_polyploid_2:
@@ -135,7 +135,7 @@ rule bedtools_intersect_special_polyploid_2:
     conda:
         "../envs/environment_downstream.yaml"
     shell:
-        "bedtools intersect -a {params.anno2} -b {input} -wo > {output} 2>&1 {log}"
+        "bedtools intersect -a {params.anno2} -b {input} -wo > {output} 2> {log}"
 
 
 # The third and final rule for downstream analyses. With overlap information and DMR information, we generate a summary file including gene ID of the genes overlapping with DMRs, all ranges for gene regions and DMRs and methylation status. Methylation status is based on the statistics given by the dmrseq output, taking condition 'A' as reference (i.e. increase means increase compared to condition 'A')
@@ -155,7 +155,7 @@ rule dmr_genes_1:
     conda:
         "../envs/environment_downstream.yaml"
     shell:
-        "Rscript scripts/DMGeneSummary.R {input.i1} {input.dm1} {params.geneID1} {params.o1} 2>&1 {log}"
+        "Rscript scripts/DMGeneSummary.R {input.i1} {input.dm1} {params.geneID1} {params.o1} 2> {log}"
 
 
 rule dmr_genes_2:
@@ -172,7 +172,7 @@ rule dmr_genes_2:
     conda:
         "../envs/environment_downstream.yaml"
     shell:
-        "Rscript scripts/DMGeneSummary.R {input.i2} {input.dm2} {params.geneID2} {params.o2} 2>&1 {log}"
+        "Rscript scripts/DMGeneSummary.R {input.i2} {input.dm2} {params.geneID2} {params.o2} 2> {log}"
 
 
 # The third downstream rules for special modes: diploid vs diploid (first below) or polyploid vs polyploid (second below). Read above for a short explanation of the rule.
@@ -193,9 +193,9 @@ rule dmr_genes_special_diploid:
     conda:
         "../envs/environment_downstream.yaml"
     shell:
-        "Rscript scripts/DMGeneSummary.R {input.i1} {input.dm1} {params.geneID1} {params.o1} 2>&1 {log}" if (
+        "Rscript scripts/DMGeneSummary.R {input.i1} {input.dm1} {params.geneID1} {params.o1} 2> {log}" if (
         sum(samples.origin == "parent1") > 0
-        ) else "Rscript scripts/DMGeneSummary.R {input.i1} {input.dm1} {params.geneID2} {params.o1} 2>&1 {log}"
+        ) else "Rscript scripts/DMGeneSummary.R {input.i1} {input.dm1} {params.geneID2} {params.o1} 2> {log}"
 
 
 rule dmr_genes_special_polyploid_1:
@@ -212,7 +212,7 @@ rule dmr_genes_special_polyploid_1:
     conda:
         "../envs/environment_downstream.yaml"
     shell:
-        "Rscript scripts/DMGeneSummary.R {input.i1} {input.dm1} {params.geneID1} {params.o1} 2>&1 {log}"
+        "Rscript scripts/DMGeneSummary.R {input.i1} {input.dm1} {params.geneID1} {params.o1} 2> {log}"
 
 
 rule dmr_genes_special_polyploid_2:
@@ -229,4 +229,4 @@ rule dmr_genes_special_polyploid_2:
     conda:
         "../envs/environment_downstream.yaml"
     shell:
-        "Rscript scripts/DMGeneSummary.R {input.i1} {input.dm1} {params.geneID2} {params.o2} 2>&1 {log}"
+        "Rscript scripts/DMGeneSummary.R {input.i1} {input.dm1} {params.geneID2} {params.o2} 2> {log}"

--- a/rules/downstream.smk
+++ b/rules/downstream.smk
@@ -15,7 +15,7 @@ rule dm_regions_bed:
     output:
         f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/parent{{one_or_two}}_v_allo_sig_sorted.bed",
     log:
-        f"{OUTPUT_DIR}/logs/dm_region_{{context}}_p{{one_or_two}}.log",
+        f"{OUTPUT_DIR}logs/dm_region_{{context}}_p{{one_or_two}}.log",
     params:
         f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/parent{{one_or_two}}_v_allo_sig",
     conda:
@@ -39,7 +39,7 @@ rule dm_regions_bed_special:
             f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/A_v_B_polyploid_sig_sorted.bed"
         ),
     log:
-        f"{OUTPUT_DIR}/logs/dm_region_{{context}}_special.log",
+        f"{OUTPUT_DIR}logs/dm_region_{{context}}_special.log",
     params:
         f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/A_v_B_diploid_sig"
         if config["DIPLOID_ONLY"]
@@ -61,7 +61,7 @@ rule bedtools_intersect_1:
     output:
         o1=f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/parent1_v_allo_genes_overlap.txt",
     log:
-        f"{OUTPUT_DIR}/logs/bedtools_{{context}}_p1.log",
+        f"{OUTPUT_DIR}logs/bedtools_{{context}}_p1.log",
     params:
         anno1=config["ANNOTATION_PARENT_1"],
     conda:
@@ -78,7 +78,7 @@ rule bedtools_intersect_2:
     output:
         o2=f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/parent2_v_allo_genes_overlap.txt",
     log:
-        f"{OUTPUT_DIR}/logs/bedtools_{{context}}_p2.log",
+        f"{OUTPUT_DIR}logs/bedtools_{{context}}_p2.log",
     params:
         anno2=config["ANNOTATION_PARENT_2"],
     conda:
@@ -96,7 +96,7 @@ rule bedtools_intersect_special_diploid:
     output:
         f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/A_v_B_diploid_genes_overlap.txt",
     log:
-        f"{OUTPUT_DIR}/logs/bedtools_{{context}}_special.log",
+        f"{OUTPUT_DIR}logs/bedtools_{{context}}_special.log",
     params:
         anno1=config["ANNOTATION_PARENT_1"],
         anno2=config["ANNOTATION_PARENT_2"],
@@ -114,7 +114,7 @@ rule bedtools_intersect_special_polyploid_1:
     output:
         f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/A_v_B_polyploid_genes_overlap_1.txt",
     log:
-        f"{OUTPUT_DIR}/logs/bedtools_{{context}}_special_1.log",
+        f"{OUTPUT_DIR}logs/bedtools_{{context}}_special_1.log",
     params:
         anno1=config["ANNOTATION_PARENT_1"],
     conda:
@@ -129,7 +129,7 @@ rule bedtools_intersect_special_polyploid_2:
     output:
         f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/A_v_B_polyploid_genes_overlap_2.txt",
     log:
-        f"{OUTPUT_DIR}/logs/bedtools_{{context}}_special_2.log",
+        f"{OUTPUT_DIR}logs/bedtools_{{context}}_special_2.log",
     params:
         anno2=config["ANNOTATION_PARENT_2"],
     conda:
@@ -148,7 +148,7 @@ rule dmr_genes_1:
     output:
         o1=f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/DM_genes_parent1_v_allo_{{context}}.txt",
     log:
-        f"{OUTPUT_DIR}/logs/dmr_genes_{{context}}_p1.log",
+        f"{OUTPUT_DIR}logs/dmr_genes_{{context}}_p1.log",
     params:
         geneID1=config["GENE_ID_PARENT_1"],
         o1=lambda w, output: os.path.splitext(output.o1)[0],
@@ -165,7 +165,7 @@ rule dmr_genes_2:
     output:
         o2=f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/DM_genes_parent2_v_allo_{{context}}.txt",
     log:
-        f"{OUTPUT_DIR}/logs/dmr_genes_{{context}}_p2.log",
+        f"{OUTPUT_DIR}logs/dmr_genes_{{context}}_p2.log",
     params:
         geneID2=config["GENE_ID_PARENT_2"],
         o2=lambda w, output: os.path.splitext(output.o2)[0],
@@ -185,7 +185,7 @@ rule dmr_genes_special_diploid:
     output:
         o1=f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/DM_genes_A_v_B_diploid_{{context}}.txt",
     log:
-        f"{OUTPUT_DIR}/logs/dmr_genes_{{context}}_special_diploid.log",
+        f"{OUTPUT_DIR}logs/dmr_genes_{{context}}_special_diploid.log",
     params:
         geneID1=config["GENE_ID_PARENT_1"],
         geneID2=config["GENE_ID_PARENT_2"],
@@ -205,7 +205,7 @@ rule dmr_genes_special_polyploid_1:
     output:
         o1=f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/DM_genes_A_v_B_polyploid_{{context}}_1.txt",
     log:
-        f"{OUTPUT_DIR}/logs/dmr_genes_{{context}}_special_polyploid1.log",
+        f"{OUTPUT_DIR}logs/dmr_genes_{{context}}_special_polyploid1.log",
     params:
         geneID1=config["GENE_ID_PARENT_1"],
         o1=lambda w, output: os.path.splitext(output.o1)[0],
@@ -222,7 +222,7 @@ rule dmr_genes_special_polyploid_2:
     output:
         o1=f"{OUTPUT_DIR}DMR_analysis/dmrseq/{{context}}/DM_genes_A_v_B_polyploid_{{context}}_2.txt",
     log:
-        f"{OUTPUT_DIR}/logs/dmr_genes_{{context}}_special_polyploid2.log",
+        f"{OUTPUT_DIR}logs/dmr_genes_{{context}}_special_polyploid2.log",
     params:
         geneID2=config["GENE_ID_PARENT_2"],
         o2=lambda w, output: os.path.splitext(output.o1)[0],

--- a/rules/methylation_extraction.smk
+++ b/rules/methylation_extraction.smk
@@ -58,7 +58,7 @@ rule methylation_extraction_SE_parent_1:
             )
         ),
     log:
-        f"{OUTPUT_DIR}/logs/methXtract_{{sample}}_SE_p1.log",
+        f"{OUTPUT_DIR}logs/methXtract_{{sample}}_SE_p1.log",
     benchmark:
         f"{OUTPUT_DIR}benchmark/extraction_se_p1_{{sample}}.txt"
     params:
@@ -128,7 +128,7 @@ rule methylation_extraction_SE_parent_2:
             )
         ),
     log:
-        f"{OUTPUT_DIR}/logs/methXtract_{{sample}}_SE_p2.log",
+        f"{OUTPUT_DIR}logs/methXtract_{{sample}}_SE_p2.log",
     benchmark:
         f"{OUTPUT_DIR}benchmark/extraction_se_p2_{{sample}}.txt"
     params:
@@ -224,7 +224,7 @@ rule methylation_extraction_SE_allo_1:
             )
         ),
     log:
-        f"{OUTPUT_DIR}/logs/methXtract_{{sample}}_SE_allo1.log",
+        f"{OUTPUT_DIR}logs/methXtract_{{sample}}_SE_allo1.log",
     benchmark:
         f"{OUTPUT_DIR}benchmark/extraction_se_allo1_{{sample}}.txt"
     params:
@@ -320,7 +320,7 @@ rule methylation_extraction_SE_allo_2:
             )
         ),
     log:
-        f"{OUTPUT_DIR}/logs/methXtract_{{sample}}_SE_allo2.log",
+        f"{OUTPUT_DIR}logs/methXtract_{{sample}}_SE_allo2.log",
     benchmark:
         f"{OUTPUT_DIR}benchmark/extraction_se_allo2_{{sample}}.txt"
     params:
@@ -397,7 +397,7 @@ rule methylation_extraction_PE_parent_1:
             )
         ),
     log:
-        f"{OUTPUT_DIR}/logs/methXtract_{{sample}}_PE_p1.log",
+        f"{OUTPUT_DIR}logs/methXtract_{{sample}}_PE_p1.log",
     benchmark:
         f"{OUTPUT_DIR}benchmark/extraction_pe_p1_{{sample}}.txt"
     params:
@@ -474,7 +474,7 @@ rule methylation_extraction_PE_parent_2:
             )
         ),
     log:
-        f"{OUTPUT_DIR}/logs/methXtract_{{sample}}_PE_p2.log",
+        f"{OUTPUT_DIR}logs/methXtract_{{sample}}_PE_p2.log",
     benchmark:
         f"{OUTPUT_DIR}benchmark/extraction_pe_p2_{{sample}}.txt"
     params:
@@ -581,7 +581,7 @@ rule methylation_extraction_PE_allo_1:
             )
         ),
     log:
-        f"{OUTPUT_DIR}/logs/methXtract_{{sample}}_PE_allo1.log",
+        f"{OUTPUT_DIR}logs/methXtract_{{sample}}_PE_allo1.log",
     benchmark:
         f"{OUTPUT_DIR}benchmark/extraction_pe_allo1_{{sample}}.txt"
     params:
@@ -688,7 +688,7 @@ rule methylation_extraction_PE_allo_2:
             )
         ),
     log:
-        f"{OUTPUT_DIR}/logs/methXtract_{{sample}}_PE_allo2.log",
+        f"{OUTPUT_DIR}logs/methXtract_{{sample}}_PE_allo2.log",
     benchmark:
         f"{OUTPUT_DIR}benchmark/extraction_pe_allo2_{{sample}}.txt"
     params:
@@ -729,7 +729,7 @@ rule coverage2cytosine_1:
     output:
         o1=f"{OUTPUT_DIR}Bismark/extraction/{{sample}}_p1/{{sample}}.CX_report.txt",
     log:
-        f"{OUTPUT_DIR}/logs/c2c_{{sample}}_p1.log",
+        f"{OUTPUT_DIR}logs/c2c_{{sample}}_p1.log",
     benchmark:
         f"{OUTPUT_DIR}benchmark/c2c_1_{{sample}}.txt"
     params:
@@ -764,7 +764,7 @@ rule coverage2cytosine_2:
     output:
         o2=f"{OUTPUT_DIR}Bismark/extraction/{{sample}}_p2/{{sample}}.CX_report.txt",
     log:
-        f"{OUTPUT_DIR}/logs/c2c_{{sample}}_p2.log",
+        f"{OUTPUT_DIR}logs/c2c_{{sample}}_p2.log",
     benchmark:
         f"{OUTPUT_DIR}benchmark/c2c_2_{{sample}}.txt"
     params:
@@ -807,7 +807,7 @@ rule coverage2cytosine_allo_1:
     output:
         o1=f"{OUTPUT_DIR}Bismark/extraction/{{sample}}_1/{{sample}}.CX_report.txt",
     log:
-        f"{OUTPUT_DIR}/logs/c2c_{{sample}}_allo1.log",
+        f"{OUTPUT_DIR}logs/c2c_{{sample}}_allo1.log",
     benchmark:
         f"{OUTPUT_DIR}benchmark/c2c_allo_{{sample}}.txt"
     params:
@@ -850,7 +850,7 @@ rule coverage2cytosine_allo_2:
     output:
         o2=f"{OUTPUT_DIR}Bismark/extraction/{{sample}}_2/{{sample}}.CX_report.txt",
     log:
-        f"{OUTPUT_DIR}/logs/c2c_{{sample}}_allo2.log",
+        f"{OUTPUT_DIR}logs/c2c_{{sample}}_allo2.log",
     benchmark:
         f"{OUTPUT_DIR}benchmark/c2c_allo_{{sample}}.txt"
     params:

--- a/rules/methylation_extraction.smk
+++ b/rules/methylation_extraction.smk
@@ -69,10 +69,10 @@ rule methylation_extraction_SE_parent_1:
         "../envs/environment.yaml"
     threads: CORES
     shell:
-        "bismark_methylation_extractor -s -o {params.output} --gzip --genome_folder {params.genome} --multicore {params.bismark_cores} --no_overlap --comprehensive --bedGraph --scaffolds --CX {input} 2>&1 {log}" if config[
+        "bismark_methylation_extractor -s -o {params.output} --gzip --genome_folder {params.genome} --multicore {params.bismark_cores} --no_overlap --comprehensive --bedGraph --scaffolds --CX {input} 2> {log}" if config[
         "UNFINISHED_GENOME"
         ] else (
-            "bismark_methylation_extractor -s -o {params.output} --gzip --genome_folder {params.genome} --multicore {params.bismark_cores} --no_overlap --comprehensive --bedGraph --CX {input} 2>&1 {log}"
+            "bismark_methylation_extractor -s -o {params.output} --gzip --genome_folder {params.genome} --multicore {params.bismark_cores} --no_overlap --comprehensive --bedGraph --CX {input} 2> {log}"
         )
 
 
@@ -139,10 +139,10 @@ rule methylation_extraction_SE_parent_2:
         "../envs/environment.yaml"
     threads: CORES
     shell:
-        "bismark_methylation_extractor -s -o {params.output} --gzip --genome_folder {params.genome} --multicore {params.bismark_cores} --no_overlap --comprehensive --bedGraph --scaffolds --CX {input} 2>&1 {log}" if config[
+        "bismark_methylation_extractor -s -o {params.output} --gzip --genome_folder {params.genome} --multicore {params.bismark_cores} --no_overlap --comprehensive --bedGraph --scaffolds --CX {input} 2> {log}" if config[
         "UNFINISHED_GENOME"
         ] else (
-            "bismark_methylation_extractor -s -o {params.output} --gzip --genome_folder {params.genome} --multicore {params.bismark_cores} --no_overlap --comprehensive --bedGraph --CX {input} 2>&1 {log}"
+            "bismark_methylation_extractor -s -o {params.output} --gzip --genome_folder {params.genome} --multicore {params.bismark_cores} --no_overlap --comprehensive --bedGraph --CX {input} 2> {log}"
         )
 
 
@@ -235,10 +235,10 @@ rule methylation_extraction_SE_allo_1:
         "../envs/environment.yaml"
     threads: CORES
     shell:
-        "bismark_methylation_extractor -s -o {params.output} --gzip --genome_folder {params.genome} --multicore {params.bismark_cores} --no_overlap --comprehensive --bedGraph --scaffolds --CX {input} 2>&1 {log}" if config[
+        "bismark_methylation_extractor -s -o {params.output} --gzip --genome_folder {params.genome} --multicore {params.bismark_cores} --no_overlap --comprehensive --bedGraph --scaffolds --CX {input} 2> {log}" if config[
         "UNFINISHED_GENOME"
         ] else (
-            "bismark_methylation_extractor -s -o {params.output} --gzip --genome_folder {params.genome} --multicore {params.bismark_cores} --no_overlap --comprehensive --bedGraph --CX {input} 2>&1 {log}"
+            "bismark_methylation_extractor -s -o {params.output} --gzip --genome_folder {params.genome} --multicore {params.bismark_cores} --no_overlap --comprehensive --bedGraph --CX {input} 2> {log}"
         )
 
 
@@ -331,10 +331,10 @@ rule methylation_extraction_SE_allo_2:
         "../envs/environment.yaml"
     threads: CORES
     shell:
-        "bismark_methylation_extractor -s -o {params.output} --gzip --genome_folder {params.genome} --multicore {params.bismark_cores} --no_overlap --comprehensive --bedGraph --scaffolds --CX {input} 2>&1 {log}" if config[
+        "bismark_methylation_extractor -s -o {params.output} --gzip --genome_folder {params.genome} --multicore {params.bismark_cores} --no_overlap --comprehensive --bedGraph --scaffolds --CX {input} 2> {log}" if config[
         "UNFINISHED_GENOME"
         ] else (
-            "bismark_methylation_extractor -s -o {params.output} --gzip --genome_folder {params.genome} --multicore {params.bismark_cores} --no_overlap --comprehensive --bedGraph --CX {input} 2>&1 {log}"
+            "bismark_methylation_extractor -s -o {params.output} --gzip --genome_folder {params.genome} --multicore {params.bismark_cores} --no_overlap --comprehensive --bedGraph --CX {input} 2> {log}"
         )
 
 
@@ -408,10 +408,10 @@ rule methylation_extraction_PE_parent_1:
         "../envs/environment.yaml"
     threads: CORES
     shell:
-        "bismark_methylation_extractor -p -o {params.output} --gzip --genome_folder {params.genome} --multicore {params.bismark_cores} --no_overlap --comprehensive --bedGraph --scaffolds --CX {input} 2>&1 {log}" if config[
+        "bismark_methylation_extractor -p -o {params.output} --gzip --genome_folder {params.genome} --multicore {params.bismark_cores} --no_overlap --comprehensive --bedGraph --scaffolds --CX {input} 2> {log}" if config[
         "UNFINISHED_GENOME"
         ] else (
-            "bismark_methylation_extractor -p -o {params.output} --gzip --genome_folder {params.genome} --multicore {params.bismark_cores} --no_overlap --comprehensive --bedGraph --CX {input} 2>&1 {log}"
+            "bismark_methylation_extractor -p -o {params.output} --gzip --genome_folder {params.genome} --multicore {params.bismark_cores} --no_overlap --comprehensive --bedGraph --CX {input} 2> {log}"
         )
 
 
@@ -485,10 +485,10 @@ rule methylation_extraction_PE_parent_2:
         "../envs/environment.yaml"
     threads: CORES
     shell:
-        "bismark_methylation_extractor -p -o {params.output} --gzip --genome_folder {params.genome} --multicore {params.bismark_cores} --no_overlap --comprehensive --bedGraph --scaffolds --CX {input} 2>&1 {log}" if config[
+        "bismark_methylation_extractor -p -o {params.output} --gzip --genome_folder {params.genome} --multicore {params.bismark_cores} --no_overlap --comprehensive --bedGraph --scaffolds --CX {input} 2> {log}" if config[
         "UNFINISHED_GENOME"
         ] else (
-            "bismark_methylation_extractor -p -o {params.output} --gzip --genome_folder {params.genome} --multicore {params.bismark_cores} --no_overlap --comprehensive --bedGraph --CX {input} 2>&1 {log}"
+            "bismark_methylation_extractor -p -o {params.output} --gzip --genome_folder {params.genome} --multicore {params.bismark_cores} --no_overlap --comprehensive --bedGraph --CX {input} 2> {log}"
         )
 
 
@@ -592,10 +592,10 @@ rule methylation_extraction_PE_allo_1:
         "../envs/environment.yaml"
     threads: CORES
     shell:
-        "bismark_methylation_extractor -p -o {params.output} --gzip --genome_folder {params.genome} --multicore {params.bismark_cores} --no_overlap --comprehensive --bedGraph --scaffolds --CX {input} 2>&1 {log}" if config[
+        "bismark_methylation_extractor -p -o {params.output} --gzip --genome_folder {params.genome} --multicore {params.bismark_cores} --no_overlap --comprehensive --bedGraph --scaffolds --CX {input} 2> {log}" if config[
         "UNFINISHED_GENOME"
         ] else (
-            "bismark_methylation_extractor -p -o {params.output} --gzip --genome_folder {params.genome} --multicore {params.bismark_cores} --no_overlap --comprehensive --bedGraph --CX {input} 2>&1 {log}"
+            "bismark_methylation_extractor -p -o {params.output} --gzip --genome_folder {params.genome} --multicore {params.bismark_cores} --no_overlap --comprehensive --bedGraph --CX {input} 2> {log}"
         )
 
 
@@ -699,10 +699,10 @@ rule methylation_extraction_PE_allo_2:
         "../envs/environment.yaml"
     threads: CORES
     shell:
-        "bismark_methylation_extractor -p -o {params.output} --gzip --genome_folder {params.genome} --multicore {params.bismark_cores} --no_overlap --comprehensive --bedGraph --scaffolds --CX {input} 2>&1 {log}" if config[
+        "bismark_methylation_extractor -p -o {params.output} --gzip --genome_folder {params.genome} --multicore {params.bismark_cores} --no_overlap --comprehensive --bedGraph --scaffolds --CX {input} 2> {log}" if config[
         "UNFINISHED_GENOME"
         ] else (
-            "bismark_methylation_extractor -p -o {params.output} --gzip --genome_folder {params.genome} --multicore {params.bismark_cores} --no_overlap --comprehensive --bedGraph --CX {input} 2>&1 {log}"
+            "bismark_methylation_extractor -p -o {params.output} --gzip --genome_folder {params.genome} --multicore {params.bismark_cores} --no_overlap --comprehensive --bedGraph --CX {input} 2> {log}"
         )
 
 
@@ -738,7 +738,7 @@ rule coverage2cytosine_1:
     conda:
         "../envs/environment.yaml"
     shell:
-        "coverage2cytosine -CX --genome_folder {params.genome1} -o {params.filename1} {input.f1} 2>&1 {log}"
+        "coverage2cytosine -CX --genome_folder {params.genome1} -o {params.filename1} {input.f1} 2> {log}"
 
 
 ## Run Bismark coverage2cytosine on extraction output to obtain a single file with information about all cytosines (parent 2)
@@ -773,7 +773,7 @@ rule coverage2cytosine_2:
     conda:
         "../envs/environment.yaml"
     shell:
-        "coverage2cytosine -CX --genome_folder {params.genome2} -o {params.filename2} {input.f2} 2>&1 {log}"
+        "coverage2cytosine -CX --genome_folder {params.genome2} -o {params.filename2} {input.f2} 2> {log}"
 
 
 ## Run Bismark coverage2cytosine on extraction output to obtain a single file with information about all cytosines (allopolyploid)
@@ -816,7 +816,7 @@ rule coverage2cytosine_allo_1:
     conda:
         "../envs/environment.yaml"
     shell:
-        "coverage2cytosine -CX --genome_folder {params.genome1} -o {params.filename1} {input.f1} 2>&1 {log}"
+        "coverage2cytosine -CX --genome_folder {params.genome1} -o {params.filename1} {input.f1} 2> {log}"
 
 
 ## Run Bismark coverage2cytosine on extraction output to obtain a single file with information about all cytosines (allopolyploid)
@@ -859,4 +859,4 @@ rule coverage2cytosine_allo_2:
     conda:
         "../envs/environment.yaml"
     shell:
-        "coverage2cytosine -CX --genome_folder {params.genome2} -o {params.filename2} {input.f2} 2>&1 {log}"
+        "coverage2cytosine -CX --genome_folder {params.genome2} -o {params.filename2} {input.f2} 2> {log}"

--- a/rules/methylation_extraction.smk
+++ b/rules/methylation_extraction.smk
@@ -58,7 +58,7 @@ rule methylation_extraction_SE_parent_1:
             )
         ),
     log:
-        f"logs/methXtract_{{sample}}_SE_p1.log",
+        f"{OUTPUT_DIR}/logs/methXtract_{{sample}}_SE_p1.log",
     benchmark:
         f"{OUTPUT_DIR}benchmark/extraction_se_p1_{{sample}}.txt"
     params:
@@ -69,10 +69,10 @@ rule methylation_extraction_SE_parent_1:
         "../envs/environment.yaml"
     threads: CORES
     shell:
-        "bismark_methylation_extractor -s -o {params.output} --gzip --genome_folder {params.genome} --multicore {params.bismark_cores} --no_overlap --comprehensive --bedGraph --scaffolds --CX {input}" if config[
+        "bismark_methylation_extractor -s -o {params.output} --gzip --genome_folder {params.genome} --multicore {params.bismark_cores} --no_overlap --comprehensive --bedGraph --scaffolds --CX {input} 2>&1 {log}" if config[
         "UNFINISHED_GENOME"
         ] else (
-            "bismark_methylation_extractor -s -o {params.output} --gzip --genome_folder {params.genome} --multicore {params.bismark_cores} --no_overlap --comprehensive --bedGraph --CX {input}"
+            "bismark_methylation_extractor -s -o {params.output} --gzip --genome_folder {params.genome} --multicore {params.bismark_cores} --no_overlap --comprehensive --bedGraph --CX {input} 2>&1 {log}"
         )
 
 
@@ -128,7 +128,7 @@ rule methylation_extraction_SE_parent_2:
             )
         ),
     log:
-        f"logs/methXtract_{{sample}}_SE_p2.log",
+        f"{OUTPUT_DIR}/logs/methXtract_{{sample}}_SE_p2.log",
     benchmark:
         f"{OUTPUT_DIR}benchmark/extraction_se_p2_{{sample}}.txt"
     params:
@@ -139,10 +139,10 @@ rule methylation_extraction_SE_parent_2:
         "../envs/environment.yaml"
     threads: CORES
     shell:
-        "bismark_methylation_extractor -s -o {params.output} --gzip --genome_folder {params.genome} --multicore {params.bismark_cores} --no_overlap --comprehensive --bedGraph --scaffolds --CX {input}" if config[
+        "bismark_methylation_extractor -s -o {params.output} --gzip --genome_folder {params.genome} --multicore {params.bismark_cores} --no_overlap --comprehensive --bedGraph --scaffolds --CX {input} 2>&1 {log}" if config[
         "UNFINISHED_GENOME"
         ] else (
-            "bismark_methylation_extractor -s -o {params.output} --gzip --genome_folder {params.genome} --multicore {params.bismark_cores} --no_overlap --comprehensive --bedGraph --CX {input}"
+            "bismark_methylation_extractor -s -o {params.output} --gzip --genome_folder {params.genome} --multicore {params.bismark_cores} --no_overlap --comprehensive --bedGraph --CX {input} 2>&1 {log}"
         )
 
 
@@ -224,7 +224,7 @@ rule methylation_extraction_SE_allo_1:
             )
         ),
     log:
-        f"logs/methXtract_{{sample}}_SE_allo1.log",
+        f"{OUTPUT_DIR}/logs/methXtract_{{sample}}_SE_allo1.log",
     benchmark:
         f"{OUTPUT_DIR}benchmark/extraction_se_allo1_{{sample}}.txt"
     params:
@@ -235,10 +235,10 @@ rule methylation_extraction_SE_allo_1:
         "../envs/environment.yaml"
     threads: CORES
     shell:
-        "bismark_methylation_extractor -s -o {params.output} --gzip --genome_folder {params.genome} --multicore {params.bismark_cores} --no_overlap --comprehensive --bedGraph --scaffolds --CX {input}" if config[
+        "bismark_methylation_extractor -s -o {params.output} --gzip --genome_folder {params.genome} --multicore {params.bismark_cores} --no_overlap --comprehensive --bedGraph --scaffolds --CX {input} 2>&1 {log}" if config[
         "UNFINISHED_GENOME"
         ] else (
-            "bismark_methylation_extractor -s -o {params.output} --gzip --genome_folder {params.genome} --multicore {params.bismark_cores} --no_overlap --comprehensive --bedGraph --CX {input}"
+            "bismark_methylation_extractor -s -o {params.output} --gzip --genome_folder {params.genome} --multicore {params.bismark_cores} --no_overlap --comprehensive --bedGraph --CX {input} 2>&1 {log}"
         )
 
 
@@ -320,7 +320,7 @@ rule methylation_extraction_SE_allo_2:
             )
         ),
     log:
-        f"logs/methXtract_{{sample}}_SE_allo2.log",
+        f"{OUTPUT_DIR}/logs/methXtract_{{sample}}_SE_allo2.log",
     benchmark:
         f"{OUTPUT_DIR}benchmark/extraction_se_allo2_{{sample}}.txt"
     params:
@@ -331,10 +331,10 @@ rule methylation_extraction_SE_allo_2:
         "../envs/environment.yaml"
     threads: CORES
     shell:
-        "bismark_methylation_extractor -s -o {params.output} --gzip --genome_folder {params.genome} --multicore {params.bismark_cores} --no_overlap --comprehensive --bedGraph --scaffolds --CX {input}" if config[
+        "bismark_methylation_extractor -s -o {params.output} --gzip --genome_folder {params.genome} --multicore {params.bismark_cores} --no_overlap --comprehensive --bedGraph --scaffolds --CX {input} 2>&1 {log}" if config[
         "UNFINISHED_GENOME"
         ] else (
-            "bismark_methylation_extractor -s -o {params.output} --gzip --genome_folder {params.genome} --multicore {params.bismark_cores} --no_overlap --comprehensive --bedGraph --CX {input}"
+            "bismark_methylation_extractor -s -o {params.output} --gzip --genome_folder {params.genome} --multicore {params.bismark_cores} --no_overlap --comprehensive --bedGraph --CX {input} 2>&1 {log}"
         )
 
 
@@ -397,7 +397,7 @@ rule methylation_extraction_PE_parent_1:
             )
         ),
     log:
-        f"logs/methXtract_{{sample}}_PE_p1.log",
+        f"{OUTPUT_DIR}/logs/methXtract_{{sample}}_PE_p1.log",
     benchmark:
         f"{OUTPUT_DIR}benchmark/extraction_pe_p1_{{sample}}.txt"
     params:
@@ -408,10 +408,10 @@ rule methylation_extraction_PE_parent_1:
         "../envs/environment.yaml"
     threads: CORES
     shell:
-        "bismark_methylation_extractor -p -o {params.output} --gzip --genome_folder {params.genome} --multicore {params.bismark_cores} --no_overlap --comprehensive --bedGraph --scaffolds --CX {input}" if config[
+        "bismark_methylation_extractor -p -o {params.output} --gzip --genome_folder {params.genome} --multicore {params.bismark_cores} --no_overlap --comprehensive --bedGraph --scaffolds --CX {input} 2>&1 {log}" if config[
         "UNFINISHED_GENOME"
         ] else (
-            "bismark_methylation_extractor -p -o {params.output} --gzip --genome_folder {params.genome} --multicore {params.bismark_cores} --no_overlap --comprehensive --bedGraph --CX {input}"
+            "bismark_methylation_extractor -p -o {params.output} --gzip --genome_folder {params.genome} --multicore {params.bismark_cores} --no_overlap --comprehensive --bedGraph --CX {input} 2>&1 {log}"
         )
 
 
@@ -474,7 +474,7 @@ rule methylation_extraction_PE_parent_2:
             )
         ),
     log:
-        f"logs/methXtract_{{sample}}_PE_p2.log",
+        f"{OUTPUT_DIR}/logs/methXtract_{{sample}}_PE_p2.log",
     benchmark:
         f"{OUTPUT_DIR}benchmark/extraction_pe_p2_{{sample}}.txt"
     params:
@@ -485,10 +485,10 @@ rule methylation_extraction_PE_parent_2:
         "../envs/environment.yaml"
     threads: CORES
     shell:
-        "bismark_methylation_extractor -p -o {params.output} --gzip --genome_folder {params.genome} --multicore {params.bismark_cores} --no_overlap --comprehensive --bedGraph --scaffolds --CX {input}" if config[
+        "bismark_methylation_extractor -p -o {params.output} --gzip --genome_folder {params.genome} --multicore {params.bismark_cores} --no_overlap --comprehensive --bedGraph --scaffolds --CX {input} 2>&1 {log}" if config[
         "UNFINISHED_GENOME"
         ] else (
-            "bismark_methylation_extractor -p -o {params.output} --gzip --genome_folder {params.genome} --multicore {params.bismark_cores} --no_overlap --comprehensive --bedGraph --CX {input}"
+            "bismark_methylation_extractor -p -o {params.output} --gzip --genome_folder {params.genome} --multicore {params.bismark_cores} --no_overlap --comprehensive --bedGraph --CX {input} 2>&1 {log}"
         )
 
 
@@ -581,7 +581,7 @@ rule methylation_extraction_PE_allo_1:
             )
         ),
     log:
-        f"logs/methXtract_{{sample}}_PE_allo1.log",
+        f"{OUTPUT_DIR}/logs/methXtract_{{sample}}_PE_allo1.log",
     benchmark:
         f"{OUTPUT_DIR}benchmark/extraction_pe_allo1_{{sample}}.txt"
     params:
@@ -592,10 +592,10 @@ rule methylation_extraction_PE_allo_1:
         "../envs/environment.yaml"
     threads: CORES
     shell:
-        "bismark_methylation_extractor -p -o {params.output} --gzip --genome_folder {params.genome} --multicore {params.bismark_cores} --no_overlap --comprehensive --bedGraph --scaffolds --CX {input}" if config[
+        "bismark_methylation_extractor -p -o {params.output} --gzip --genome_folder {params.genome} --multicore {params.bismark_cores} --no_overlap --comprehensive --bedGraph --scaffolds --CX {input} 2>&1 {log}" if config[
         "UNFINISHED_GENOME"
         ] else (
-            "bismark_methylation_extractor -p -o {params.output} --gzip --genome_folder {params.genome} --multicore {params.bismark_cores} --no_overlap --comprehensive --bedGraph --CX {input}"
+            "bismark_methylation_extractor -p -o {params.output} --gzip --genome_folder {params.genome} --multicore {params.bismark_cores} --no_overlap --comprehensive --bedGraph --CX {input} 2>&1 {log}"
         )
 
 
@@ -688,7 +688,7 @@ rule methylation_extraction_PE_allo_2:
             )
         ),
     log:
-        f"logs/methXtract_{{sample}}_PE_allo2.log",
+        f"{OUTPUT_DIR}/logs/methXtract_{{sample}}_PE_allo2.log",
     benchmark:
         f"{OUTPUT_DIR}benchmark/extraction_pe_allo2_{{sample}}.txt"
     params:
@@ -699,10 +699,10 @@ rule methylation_extraction_PE_allo_2:
         "../envs/environment.yaml"
     threads: CORES
     shell:
-        "bismark_methylation_extractor -p -o {params.output} --gzip --genome_folder {params.genome} --multicore {params.bismark_cores} --no_overlap --comprehensive --bedGraph --scaffolds --CX {input}" if config[
+        "bismark_methylation_extractor -p -o {params.output} --gzip --genome_folder {params.genome} --multicore {params.bismark_cores} --no_overlap --comprehensive --bedGraph --scaffolds --CX {input} 2>&1 {log}" if config[
         "UNFINISHED_GENOME"
         ] else (
-            "bismark_methylation_extractor -p -o {params.output} --gzip --genome_folder {params.genome} --multicore {params.bismark_cores} --no_overlap --comprehensive --bedGraph --CX {input}"
+            "bismark_methylation_extractor -p -o {params.output} --gzip --genome_folder {params.genome} --multicore {params.bismark_cores} --no_overlap --comprehensive --bedGraph --CX {input} 2>&1 {log}"
         )
 
 
@@ -729,7 +729,7 @@ rule coverage2cytosine_1:
     output:
         o1=f"{OUTPUT_DIR}Bismark/extraction/{{sample}}_p1/{{sample}}.CX_report.txt",
     log:
-        f"logs/c2c_{{sample}}_p1.log",
+        f"{OUTPUT_DIR}/logs/c2c_{{sample}}_p1.log",
     benchmark:
         f"{OUTPUT_DIR}benchmark/c2c_1_{{sample}}.txt"
     params:
@@ -738,7 +738,7 @@ rule coverage2cytosine_1:
     conda:
         "../envs/environment.yaml"
     shell:
-        "coverage2cytosine -CX --genome_folder {params.genome1} -o {params.filename1} {input.f1}"
+        "coverage2cytosine -CX --genome_folder {params.genome1} -o {params.filename1} {input.f1} 2>&1 {log}"
 
 
 ## Run Bismark coverage2cytosine on extraction output to obtain a single file with information about all cytosines (parent 2)
@@ -764,7 +764,7 @@ rule coverage2cytosine_2:
     output:
         o2=f"{OUTPUT_DIR}Bismark/extraction/{{sample}}_p2/{{sample}}.CX_report.txt",
     log:
-        f"logs/c2c_{{sample}}_p2.log",
+        f"{OUTPUT_DIR}/logs/c2c_{{sample}}_p2.log",
     benchmark:
         f"{OUTPUT_DIR}benchmark/c2c_2_{{sample}}.txt"
     params:
@@ -773,7 +773,7 @@ rule coverage2cytosine_2:
     conda:
         "../envs/environment.yaml"
     shell:
-        "coverage2cytosine -CX --genome_folder {params.genome2} -o {params.filename2} {input.f2}"
+        "coverage2cytosine -CX --genome_folder {params.genome2} -o {params.filename2} {input.f2} 2>&1 {log}"
 
 
 ## Run Bismark coverage2cytosine on extraction output to obtain a single file with information about all cytosines (allopolyploid)
@@ -807,7 +807,7 @@ rule coverage2cytosine_allo_1:
     output:
         o1=f"{OUTPUT_DIR}Bismark/extraction/{{sample}}_1/{{sample}}.CX_report.txt",
     log:
-        f"logs/c2c_{{sample}}_allo1.log",
+        f"{OUTPUT_DIR}/logs/c2c_{{sample}}_allo1.log",
     benchmark:
         f"{OUTPUT_DIR}benchmark/c2c_allo_{{sample}}.txt"
     params:
@@ -816,7 +816,7 @@ rule coverage2cytosine_allo_1:
     conda:
         "../envs/environment.yaml"
     shell:
-        "coverage2cytosine -CX --genome_folder {params.genome1} -o {params.filename1} {input.f1}"
+        "coverage2cytosine -CX --genome_folder {params.genome1} -o {params.filename1} {input.f1} 2>&1 {log}"
 
 
 ## Run Bismark coverage2cytosine on extraction output to obtain a single file with information about all cytosines (allopolyploid)
@@ -850,7 +850,7 @@ rule coverage2cytosine_allo_2:
     output:
         o2=f"{OUTPUT_DIR}Bismark/extraction/{{sample}}_2/{{sample}}.CX_report.txt",
     log:
-        f"logs/c2c_{{sample}}_allo2.log",
+        f"{OUTPUT_DIR}/logs/c2c_{{sample}}_allo2.log",
     benchmark:
         f"{OUTPUT_DIR}benchmark/c2c_allo_{{sample}}.txt"
     params:
@@ -859,4 +859,4 @@ rule coverage2cytosine_allo_2:
     conda:
         "../envs/environment.yaml"
     shell:
-        "coverage2cytosine -CX --genome_folder {params.genome2} -o {params.filename2} {input.f2}"
+        "coverage2cytosine -CX --genome_folder {params.genome2} -o {params.filename2} {input.f2} 2>&1 {log}"

--- a/rules/quality_check.smk
+++ b/rules/quality_check.smk
@@ -23,7 +23,7 @@ rule quality_control:
         "../envs/environment.yaml"
     threads: CORES
     shell:
-        "fastqc -o {params.FastQC} -t {threads} {input.fastq} 2>&1 {log}"
+        "fastqc -o {params.FastQC} -t {threads} {input.fastq} 2> {log}"
 
 
 ## Run FastQC on SE trimmed reads resulting from trim_galore
@@ -44,7 +44,7 @@ rule quality_control_trimmed_SE:
         "../envs/environment.yaml"
     threads: CORES
     shell:
-        "fastqc -o {params.FastQC} -t {threads} {input.fastq} 2>&1 {log}"
+        "fastqc -o {params.FastQC} -t {threads} {input.fastq} 2> {log}"
 
 
 ## Run FastQC on PE trimmed reads resulting from trim_galore
@@ -67,7 +67,7 @@ rule quality_control_trimmed_PE:
         "../envs/environment.yaml"
     threads: CORES
     shell:
-        "fastqc -o {params.FastQC} -t {threads} {input} 2>&1 {log}"
+        "fastqc -o {params.FastQC} -t {threads} {input} 2> {log}"
 
 
 ## Run Bismark to prepare synthetic bisulfite converted control genome to check conversion efficiency
@@ -85,7 +85,7 @@ rule bismark_prepare_control:
     conda:
         "../envs/environment.yaml"
     shell:
-        "bismark_genome_preparation {input.control} 2>&1 {log}"
+        "bismark_genome_preparation {input.control} 2> {log}"
 
 
 ## Run Bismark to perform alignment to the control genome to check conversion efficiency if reads are single-end.
@@ -119,7 +119,7 @@ rule bismark_alignment_SE_control:
         "../envs/environment.yaml"
     threads: CORES
     shell:
-        "bismark --prefix {params.prefix} --multicore {params.bismark_cores}  -o {params.output} --temp_dir {params.output} --genome {params.control} {input.fastq} 2>&1 {log}"
+        "bismark --prefix {params.prefix} --multicore {params.bismark_cores}  -o {params.output} --temp_dir {params.output} --genome {params.control} {input.fastq} 2> {log}"
 
 
 rule bismark_alignment_PE_control:
@@ -153,7 +153,7 @@ rule bismark_alignment_PE_control:
         "../envs/environment.yaml"
     threads: CORES
     shell:
-        "bismark --prefix {params.prefix} --multicore {params.bismark_cores} --genome {params.control} -1 {input.fastq1} -2 {input.fastq2} -o {params.output} --temp_dir {params.output} 2>&1 {log}"
+        "bismark --prefix {params.prefix} --multicore {params.bismark_cores} --genome {params.control} -1 {input.fastq1} -2 {input.fastq2} -o {params.output} --temp_dir {params.output} 2> {log}"
 
 
 # sort bam files for multiqc (parent1)
@@ -209,7 +209,7 @@ rule bam_sorting_p2:
     conda:
         "../envs/environment.yaml"
     shell:
-        "samtools sort {input.p2} > {output.o2} 2>&1 {log}"
+        "samtools sort {input.p2} > {output.o2} 2> {log}"
 
 
 # sort bam files for multiqc (allopolyploid)
@@ -274,7 +274,7 @@ rule qualimap_p1:
         "../envs/environment2.yaml"
     threads: CORES
     shell:
-        "qualimap bamqc -bam {input} -outdir {params.output} -nt {threads} --java-mem-size=4G 2>&1 {log}"
+        "qualimap bamqc -bam {input} -outdir {params.output} -nt {threads} --java-mem-size=4G 2> {log}"
 
 
 ## Qualimap rule to get statistics about bam files for parent2
@@ -303,7 +303,7 @@ rule qualimap_p2:
         "../envs/environment2.yaml"
     threads: CORES
     shell:
-        "qualimap bamqc -bam {input} -outdir {params.output} -nt {threads} --java-mem-size=4G 2>&1 {log}"
+        "qualimap bamqc -bam {input} -outdir {params.output} -nt {threads} --java-mem-size=4G 2> {log}"
 
 
 ## Qualimap rule to get statistics about bam files for allopolyploid SE reads
@@ -328,7 +328,7 @@ rule qualimap_allo_se:
         "../envs/environment2.yaml"
     threads: CORES
     shell:
-        "qualimap bamqc -bam {input.genome} -outdir {params.output} -nt {threads} --java-mem-size=4G 2>&1 {log}"
+        "qualimap bamqc -bam {input.genome} -outdir {params.output} -nt {threads} --java-mem-size=4G 2> {log}"
 
 
 ## Qualimap rule to get statistics about bam files for allopolyploid PE reads
@@ -353,7 +353,7 @@ rule qualimap_allo_pe:
         "../envs/environment2.yaml"
     threads: CORES
     shell:
-        "qualimap bamqc -bam {input.genome} -outdir {params.output} -nt {threads} --java-mem-size=4G 2>&1 {log}"
+        "qualimap bamqc -bam {input.genome} -outdir {params.output} -nt {threads} --java-mem-size=4G 2> {log}"
 
 
 ## Run MultiQC to combine all the outputs from QC, trimming and alignment in a single nice report
@@ -374,4 +374,4 @@ rule multiqc:
     conda:
         "../envs/environment.yaml"
     shell:
-        "multiqc {params.inputdir} -f -o {params.multiqcdir} 2>&1 {log}"
+        "multiqc {params.inputdir} -f -o {params.multiqcdir} 2> {log}"

--- a/rules/quality_check.smk
+++ b/rules/quality_check.smk
@@ -16,7 +16,7 @@ rule quality_control:
     params:
         FastQC=lambda w, output: os.path.split(output.o1)[0],
     log:
-        f"{OUTPUT_DIR}/logs/qc_{{sample}}.log",
+        f"{OUTPUT_DIR}logs/qc_{{sample}}.log",
     benchmark:
         f"{OUTPUT_DIR}benchmark/qc_{{sample}}.txt"
     conda:
@@ -37,7 +37,7 @@ rule quality_control_trimmed_SE:
     params:
         FastQC=lambda w, output: os.path.split(output.o1)[0],
     log:
-        f"{OUTPUT_DIR}/logs/qc_{{sample}}_trimmedSE.log",
+        f"{OUTPUT_DIR}logs/qc_{{sample}}_trimmedSE.log",
     benchmark:
         f"{OUTPUT_DIR}benchmark/qc_trim_se_{{sample}}.txt"
     conda:
@@ -60,7 +60,7 @@ rule quality_control_trimmed_PE:
     params:
         FastQC=lambda w, output: os.path.split(output.o1)[0],
     log:
-        f"{OUTPUT_DIR}/logs/qc_{{sample}}_trimmedPE.log",
+        f"{OUTPUT_DIR}logs/qc_{{sample}}_trimmedPE.log",
     benchmark:
         f"{OUTPUT_DIR}benchmark/qc_trim_pe_{{sample}}.txt"
     conda:
@@ -79,7 +79,7 @@ rule bismark_prepare_control:
     output:
         f"{CONTROL_GENOME}Bisulfite_Genome/CT_conversion/genome_mfa.CT_conversion.fa",
     log:
-        f"{OUTPUT_DIR}/logs/bismark_prepare_control.log",
+        f"{OUTPUT_DIR}logs/bismark_prepare_control.log",
     benchmark:
         f"{OUTPUT_DIR}benchmark/prepare_control_genome.txt"
     conda:
@@ -105,7 +105,7 @@ rule bismark_alignment_SE_control:
         if config["RUN_TRIMMING"]
         else f"{OUTPUT_DIR}Conversion_efficiency/{{sample}}/cc.{{sample}}_bismark_bt2_SE_report.txt",
     log:
-        f"{OUTPUT_DIR}/logs/bismark_alignment_SE_{{sample}}_control.log",
+        f"{OUTPUT_DIR}logs/bismark_alignment_SE_{{sample}}_control.log",
     params:
         output=lambda w, output: os.path.split(output.sample)[0],
         control=lambda w, input: os.path.split(
@@ -139,7 +139,7 @@ rule bismark_alignment_PE_control:
         if config["RUN_TRIMMING"]
         else f"{OUTPUT_DIR}Conversion_efficiency/{{sample}}/cc.{{sample}}_{str(config['PAIR_1'])}_bismark_bt2_PE_report.txt",
     log:
-        f"{OUTPUT_DIR}/logs/bismark_alignment_PE_{{sample}}_control.log",
+        f"{OUTPUT_DIR}logs/bismark_alignment_PE_{{sample}}_control.log",
     params:
         output=lambda w, output: os.path.split(output.sample)[0],
         control=lambda w, input: os.path.split(
@@ -177,7 +177,7 @@ rule bam_sorting_p1:
         if config["RUN_TRIMMING"]
         else f"{OUTPUT_DIR}Bismark/deduplication/{{sample}}_1/1.{{sample}}_bismark_bt2.deduplicated_sorted.bam",
     log:
-        f"{OUTPUT_DIR}/logs/bam_sorting_{{sample}}_p1.log",
+        f"{OUTPUT_DIR}logs/bam_sorting_{{sample}}_p1.log",
     conda:
         "../envs/environment.yaml"
     shell:
@@ -205,7 +205,7 @@ rule bam_sorting_p2:
         if config["RUN_TRIMMING"]
         else f"{OUTPUT_DIR}Bismark/deduplication/{{sample}}_2/2.{{sample}}_bismark_bt2.deduplicated_sorted.bam",
     log:
-        f"{OUTPUT_DIR}/logs/bam_sorting_{{sample}}_p2.log",
+        f"{OUTPUT_DIR}logs/bam_sorting_{{sample}}_p2.log",
     conda:
         "../envs/environment.yaml"
     shell:
@@ -241,7 +241,7 @@ rule bam_sorting_allo:
         if config["RUN_TRIMMING"]
         else f"{OUTPUT_DIR}Bismark/deduplication/{{sample}}_{{one_or_two}}/{{one_or_two}}.{{sample}}_bismark_bt2.deduplicated_sorted_allo.bam",
     log:
-        f"{OUTPUT_DIR}/logs/bam_sorting_{{sample}}_{{one_or_two}}allo.log",
+        f"{OUTPUT_DIR}logs/bam_sorting_{{sample}}_{{one_or_two}}allo.log",
     conda:
         "../envs/environment.yaml"
     shell:
@@ -265,7 +265,7 @@ rule qualimap_p1:
     output:
         o1=f"{OUTPUT_DIR}qualimap/{{sample}}_p1/qualimapReport.html",
     log:
-        f"{OUTPUT_DIR}/logs/qualimap_{{sample}}_p1.log",
+        f"{OUTPUT_DIR}logs/qualimap_{{sample}}_p1.log",
     benchmark:
         f"{OUTPUT_DIR}benchmark/qualimap_p1_{{sample}}.txt"
     params:
@@ -294,7 +294,7 @@ rule qualimap_p2:
     output:
         o1=f"{OUTPUT_DIR}qualimap/{{sample}}_p2/qualimapReport.html",
     log:
-        f"{OUTPUT_DIR}/logs/qualimap_{{sample}}_p2.log",
+        f"{OUTPUT_DIR}logs/qualimap_{{sample}}_p2.log",
     benchmark:
         f"{OUTPUT_DIR}benchmark/qualimap_p2_{{sample}}.txt"
     params:
@@ -319,7 +319,7 @@ rule qualimap_allo_se:
     output:
         o1=f"{OUTPUT_DIR}qualimap/{{sample}}_allo_se_{{one_or_two}}/qualimapReport.html",
     log:
-        f"{OUTPUT_DIR}/logs/qualimap_{{sample}}_{{one_or_two}}_alloSE.log",
+        f"{OUTPUT_DIR}logs/qualimap_{{sample}}_{{one_or_two}}_alloSE.log",
     benchmark:
         f"{OUTPUT_DIR}benchmark/qualimap_allo_se_{{sample}}_{{one_or_two}}.txt"
     params:
@@ -344,7 +344,7 @@ rule qualimap_allo_pe:
     output:
         o1=f"{OUTPUT_DIR}qualimap/{{sample}}_allo_pe_{{one_or_two}}/qualimapReport.html",
     log:
-        f"{OUTPUT_DIR}/logs/qualimap_{{sample}}_{{one_or_two}}_alloPE.log",
+        f"{OUTPUT_DIR}logs/qualimap_{{sample}}_{{one_or_two}}_alloPE.log",
     benchmark:
         f"{OUTPUT_DIR}benchmark/qualimap_allo_pe_{{sample}}_{{one_or_two}}.txt"
     params:
@@ -365,7 +365,7 @@ rule multiqc:
     output:
         o1=f"{OUTPUT_DIR}MultiQC/multiqc_report.html",
     log:
-        f"{OUTPUT_DIR}/logs/multiqc.log",
+        f"{OUTPUT_DIR}logs/multiqc.log",
     params:
         inputdir=multiqc_params,
         multiqcdir=lambda w, output: os.path.split(output.o1)[0],

--- a/rules/read_sorting.smk
+++ b/rules/read_sorting.smk
@@ -23,7 +23,7 @@ rule read_sorting_SE:
         o1=f"{OUTPUT_DIR}read_sorting/{{sample}}_se/{{sample}}_classified1.ref.bam",
         o2=f"{OUTPUT_DIR}read_sorting/{{sample}}_se/{{sample}}_classified2.ref.bam",
     log:
-        f"logs/read_sorting_{{sample}}_SE.log",
+        f"{OUTPUT_DIR}/logs/read_sorting_{{sample}}_SE.log",
     benchmark:
         f"{OUTPUT_DIR}benchmark/readsorting_se_{{sample}}.txt"
     params:
@@ -35,7 +35,7 @@ rule read_sorting_SE:
             :-1
         ],
     shell:
-        "{input.eagle_bin} --ngi {params.phred} --ref1={params.genome1} --bam1={input.reads1} --ref2={params.genome2} --bam2={input.reads2} -o {params.output} --bs=3 > {params.list}"
+        "{input.eagle_bin} --ngi {params.phred} --ref1={params.genome1} --bam1={input.reads1} --ref2={params.genome2} --bam2={input.reads2} -o {params.output} --bs=3 > {params.list} 2>&1 {log}"
 
 
 ## Run EAGLE-RC to classify reads to the most probable genome for PE reads
@@ -54,7 +54,7 @@ rule read_sorting_PE:
         o1=f"{OUTPUT_DIR}read_sorting/{{sample}}/{{sample}}_classified1.ref.bam",
         o2=f"{OUTPUT_DIR}read_sorting/{{sample}}/{{sample}}_classified2.ref.bam",
     log:
-        f"logs/read_sorting_{{sample}}_PE.log",
+        f"{OUTPUT_DIR}/logs/read_sorting_{{sample}}_PE.log",
     benchmark:
         f"{OUTPUT_DIR}benchmark/readsorting_pe_{{sample}}.txt"
     params:
@@ -66,4 +66,4 @@ rule read_sorting_PE:
             :-1
         ],
     shell:
-        "{input.eagle_bin} --ngi --paired {params.phred} --ref1={params.genome1} --bam1={input.reads1} --ref2={params.genome2} --bam2={input.reads2} -o {params.output} --bs=3 > {params.list}"
+        "{input.eagle_bin} --ngi --paired {params.phred} --ref1={params.genome1} --bam1={input.reads1} --ref2={params.genome2} --bam2={input.reads2} -o {params.output} --bs=3 > {params.list} 2>&1 {log}"

--- a/rules/read_sorting.smk
+++ b/rules/read_sorting.smk
@@ -35,7 +35,7 @@ rule read_sorting_SE:
             :-1
         ],
     shell:
-        "{input.eagle_bin} --ngi {params.phred} --ref1={params.genome1} --bam1={input.reads1} --ref2={params.genome2} --bam2={input.reads2} -o {params.output} --bs=3 > {params.list} 2>&1 {log}"
+        "{input.eagle_bin} --ngi {params.phred} --ref1={params.genome1} --bam1={input.reads1} --ref2={params.genome2} --bam2={input.reads2} -o {params.output} --bs=3 > {params.list} 2> {log}"
 
 
 ## Run EAGLE-RC to classify reads to the most probable genome for PE reads
@@ -66,4 +66,4 @@ rule read_sorting_PE:
             :-1
         ],
     shell:
-        "{input.eagle_bin} --ngi --paired {params.phred} --ref1={params.genome1} --bam1={input.reads1} --ref2={params.genome2} --bam2={input.reads2} -o {params.output} --bs=3 > {params.list} 2>&1 {log}"
+        "{input.eagle_bin} --ngi --paired {params.phred} --ref1={params.genome1} --bam1={input.reads1} --ref2={params.genome2} --bam2={input.reads2} -o {params.output} --bs=3 > {params.list} 2> {log}"

--- a/rules/read_sorting.smk
+++ b/rules/read_sorting.smk
@@ -23,7 +23,7 @@ rule read_sorting_SE:
         o1=f"{OUTPUT_DIR}read_sorting/{{sample}}_se/{{sample}}_classified1.ref.bam",
         o2=f"{OUTPUT_DIR}read_sorting/{{sample}}_se/{{sample}}_classified2.ref.bam",
     log:
-        f"{OUTPUT_DIR}/logs/read_sorting_{{sample}}_SE.log",
+        f"{OUTPUT_DIR}logs/read_sorting_{{sample}}_SE.log",
     benchmark:
         f"{OUTPUT_DIR}benchmark/readsorting_se_{{sample}}.txt"
     params:
@@ -54,7 +54,7 @@ rule read_sorting_PE:
         o1=f"{OUTPUT_DIR}read_sorting/{{sample}}/{{sample}}_classified1.ref.bam",
         o2=f"{OUTPUT_DIR}read_sorting/{{sample}}/{{sample}}_classified2.ref.bam",
     log:
-        f"{OUTPUT_DIR}/logs/read_sorting_{{sample}}_PE.log",
+        f"{OUTPUT_DIR}logs/read_sorting_{{sample}}_PE.log",
     benchmark:
         f"{OUTPUT_DIR}benchmark/readsorting_pe_{{sample}}.txt"
     params:

--- a/rules/trimming.smk
+++ b/rules/trimming.smk
@@ -27,7 +27,7 @@ rule trim_galore_se:
     conda:
         "../envs/environment.yaml"
     shell:
-        "trim_galore -q 20 --clip_R1 {params.trim_5_r1} --phred33 --length 20 -j {params.trim_cores} -o {params.FASTQtrimmeddir} --path_to_cutadapt cutadapt {input.fastq1} 2>&1 {log}" if config[
+        "trim_galore -q 20 --clip_R1 {params.trim_5_r1} --phred33 --length 20 -j {params.trim_cores} -o {params.FASTQtrimmeddir} --path_to_cutadapt cutadapt {input.fastq1} 2> {log}" if config[
         "RUN_TRIMMING"
         ] and config[
             "TRIM_5_ONLY"
@@ -67,7 +67,7 @@ rule trim_galore_pe:
     conda:
         "../envs/environment.yaml"
     shell:
-        "trim_galore -q 20 --clip_R1 {params.trim_5_r1} --clip_R2 {params.trim_5_r2} --phred33 --length 20 -j {params.trim_cores} -o {params.FASTQtrimmeddir} --path_to_cutadapt cutadapt --paired {input.fastq1} {input.fastq2} 2>&1 {log}" if config[
+        "trim_galore -q 20 --clip_R1 {params.trim_5_r1} --clip_R2 {params.trim_5_r2} --phred33 --length 20 -j {params.trim_cores} -o {params.FASTQtrimmeddir} --path_to_cutadapt cutadapt --paired {input.fastq1} {input.fastq2} 2> {log}" if config[
         "RUN_TRIMMING"
         ] and config[
             "TRIM_5_ONLY"

--- a/rules/trimming.smk
+++ b/rules/trimming.smk
@@ -32,12 +32,12 @@ rule trim_galore_se:
         ] and config[
             "TRIM_5_ONLY"
         ] else (
-            "trim_galore -q 20 --clip_R1 {params.trim_5_r1}  --three_prime_clip_R1 {params.trim_3_r1} --phred33 --length 20 -j {params.trim_cores} -o {params.FASTQtrimmeddir} --path_to_cutadapt cutadapt {input.fastq1} 2>&1 {log}"
+            "trim_galore -q 20 --clip_R1 {params.trim_5_r1}  --three_prime_clip_R1 {params.trim_3_r1} --phred33 --length 20 -j {params.trim_cores} -o {params.FASTQtrimmeddir} --path_to_cutadapt cutadapt {input.fastq1} 2> {log}"
             if config["RUN_TRIMMING"] and config["TRIM_3_ONLY"]
             else (
-                "trim_galore -q 20 --clip_R1 {params.trim_5_r1}  --three_prime_clip_R1 {params.trim_3_r1} --phred33 --length 20 -j {params.trim_cores} -o {params.FASTQtrimmeddir} --path_to_cutadapt cutadapt {input.fastq1} 2>&1 {log}"
+                "trim_galore -q 20 --clip_R1 {params.trim_5_r1}  --three_prime_clip_R1 {params.trim_3_r1} --phred33 --length 20 -j {params.trim_cores} -o {params.FASTQtrimmeddir} --path_to_cutadapt cutadapt {input.fastq1} 2> {log}"
                 if config["RUN_TRIMMING"]
-                else "trim_galore -q 20 --phred33 --length 20 -j {params.trim_cores} -o {params.FASTQtrimmeddir} --path_to_cutadapt cutadapt {input.fastq1} 2>&1 {log}"
+                else "trim_galore -q 20 --phred33 --length 20 -j {params.trim_cores} -o {params.FASTQtrimmeddir} --path_to_cutadapt cutadapt {input.fastq1} 2> {log}"
             )
         )
 
@@ -72,11 +72,11 @@ rule trim_galore_pe:
         ] and config[
             "TRIM_5_ONLY"
         ] else (
-            "trim_galore -q 20 --three_prime_clip_R1 {params.trim_3_r1} --three_prime_clip_R2 {params.trim_3_r2} --phred33 --length 20 -j {params.trim_cores} -o {params.FASTQtrimmeddir} --path_to_cutadapt cutadapt --paired {input.fastq1} {input.fastq2} 2>&1 {log}"
+            "trim_galore -q 20 --three_prime_clip_R1 {params.trim_3_r1} --three_prime_clip_R2 {params.trim_3_r2} --phred33 --length 20 -j {params.trim_cores} -o {params.FASTQtrimmeddir} --path_to_cutadapt cutadapt --paired {input.fastq1} {input.fastq2} 2> {log}"
             if config["RUN_TRIMMING"] and config["TRIM_3_ONLY"]
             else (
-                "trim_galore -q 20 --clip_R1 {params.trim_5_r1} --clip_R2 {params.trim_5_r2} --three_prime_clip_R1 {params.trim_3_r1} --three_prime_clip_R2 {params.trim_3_r2} --phred33 --length 20 -j {params.trim_cores} -o {params.FASTQtrimmeddir} --path_to_cutadapt cutadapt --paired {input.fastq1} {input.fastq2} 2>&1 {log}"
+                "trim_galore -q 20 --clip_R1 {params.trim_5_r1} --clip_R2 {params.trim_5_r2} --three_prime_clip_R1 {params.trim_3_r1} --three_prime_clip_R2 {params.trim_3_r2} --phred33 --length 20 -j {params.trim_cores} -o {params.FASTQtrimmeddir} --path_to_cutadapt cutadapt --paired {input.fastq1} {input.fastq2} 2> {log}"
                 if config["RUN_TRIMMING"]
-                else "trim_galore -q 20 --phred33 --length 20 -j {params.trim_cores} -o {params.FASTQtrimmeddir} --path_to_cutadapt cutadapt --paired {input.fastq1} {input.fastq2} 2>&1 {log}"
+                else "trim_galore -q 20 --phred33 --length 20 -j {params.trim_cores} -o {params.FASTQtrimmeddir} --path_to_cutadapt cutadapt --paired {input.fastq1} {input.fastq2} 2> {log}"
             )
         )

--- a/rules/trimming.smk
+++ b/rules/trimming.smk
@@ -15,7 +15,7 @@ rule trim_galore_se:
     output:
         o1=f"{OUTPUT_DIR}FASTQtrimmed/{{sample}}_trimmed.fq.gz",
     log:
-        f"logs/trim_galore_{{sample}}_se.log",
+        f"{OUTPUT_DIR}/logs/trim_galore_{{sample}}_se.log",
     params:
         FASTQtrimmeddir=lambda w, output: os.path.split(output.o1)[0],
         trim_5_r1=config["CLIP_5_R1"],
@@ -27,17 +27,17 @@ rule trim_galore_se:
     conda:
         "../envs/environment.yaml"
     shell:
-        "trim_galore -q 20 --clip_R1 {params.trim_5_r1} --phred33 --length 20 -j {params.trim_cores} -o {params.FASTQtrimmeddir} --path_to_cutadapt cutadapt {input.fastq1}" if config[
+        "trim_galore -q 20 --clip_R1 {params.trim_5_r1} --phred33 --length 20 -j {params.trim_cores} -o {params.FASTQtrimmeddir} --path_to_cutadapt cutadapt {input.fastq1} 2>&1 {log}" if config[
         "RUN_TRIMMING"
         ] and config[
             "TRIM_5_ONLY"
         ] else (
-            "trim_galore -q 20 --clip_R1 {params.trim_5_r1}  --three_prime_clip_R1 {params.trim_3_r1} --phred33 --length 20 -j {params.trim_cores} -o {params.FASTQtrimmeddir} --path_to_cutadapt cutadapt {input.fastq1}"
+            "trim_galore -q 20 --clip_R1 {params.trim_5_r1}  --three_prime_clip_R1 {params.trim_3_r1} --phred33 --length 20 -j {params.trim_cores} -o {params.FASTQtrimmeddir} --path_to_cutadapt cutadapt {input.fastq1} 2>&1 {log}"
             if config["RUN_TRIMMING"] and config["TRIM_3_ONLY"]
             else (
-                "trim_galore -q 20 --clip_R1 {params.trim_5_r1}  --three_prime_clip_R1 {params.trim_3_r1} --phred33 --length 20 -j {params.trim_cores} -o {params.FASTQtrimmeddir} --path_to_cutadapt cutadapt {input.fastq1}"
+                "trim_galore -q 20 --clip_R1 {params.trim_5_r1}  --three_prime_clip_R1 {params.trim_3_r1} --phred33 --length 20 -j {params.trim_cores} -o {params.FASTQtrimmeddir} --path_to_cutadapt cutadapt {input.fastq1} 2>&1 {log}"
                 if config["RUN_TRIMMING"]
-                else "trim_galore -q 20 --phred33 --length 20 -j {params.trim_cores} -o {params.FASTQtrimmeddir} --path_to_cutadapt cutadapt {input.fastq1}"
+                else "trim_galore -q 20 --phred33 --length 20 -j {params.trim_cores} -o {params.FASTQtrimmeddir} --path_to_cutadapt cutadapt {input.fastq1} 2>&1 {log}"
             )
         )
 
@@ -53,7 +53,7 @@ rule trim_galore_pe:
         o1=f"{OUTPUT_DIR}FASTQtrimmed/{{sample}}_{str(config['PAIR_1'])}_val_1.fq.gz",
         o2=f"{OUTPUT_DIR}FASTQtrimmed/{{sample}}_{str(config['PAIR_2'])}_val_2.fq.gz",
     log:
-        f"logs/trim_galore_{{sample}}_pe.log",
+        f"{OUTPUT_DIR}/logs/trim_galore_{{sample}}_pe.log",
     params:
         FASTQtrimmeddir=lambda w, output: os.path.split(output.o1)[0],
         trim_5_r1=config["CLIP_5_R1"],
@@ -67,16 +67,16 @@ rule trim_galore_pe:
     conda:
         "../envs/environment.yaml"
     shell:
-        "trim_galore -q 20 --clip_R1 {params.trim_5_r1} --clip_R2 {params.trim_5_r2} --phred33 --length 20 -j {params.trim_cores} -o {params.FASTQtrimmeddir} --path_to_cutadapt cutadapt --paired {input.fastq1} {input.fastq2}" if config[
+        "trim_galore -q 20 --clip_R1 {params.trim_5_r1} --clip_R2 {params.trim_5_r2} --phred33 --length 20 -j {params.trim_cores} -o {params.FASTQtrimmeddir} --path_to_cutadapt cutadapt --paired {input.fastq1} {input.fastq2} 2>&1 {log}" if config[
         "RUN_TRIMMING"
         ] and config[
             "TRIM_5_ONLY"
         ] else (
-            "trim_galore -q 20 --three_prime_clip_R1 {params.trim_3_r1} --three_prime_clip_R2 {params.trim_3_r2} --phred33 --length 20 -j {params.trim_cores} -o {params.FASTQtrimmeddir} --path_to_cutadapt cutadapt --paired {input.fastq1} {input.fastq2}"
+            "trim_galore -q 20 --three_prime_clip_R1 {params.trim_3_r1} --three_prime_clip_R2 {params.trim_3_r2} --phred33 --length 20 -j {params.trim_cores} -o {params.FASTQtrimmeddir} --path_to_cutadapt cutadapt --paired {input.fastq1} {input.fastq2} 2>&1 {log}"
             if config["RUN_TRIMMING"] and config["TRIM_3_ONLY"]
             else (
-                "trim_galore -q 20 --clip_R1 {params.trim_5_r1} --clip_R2 {params.trim_5_r2} --three_prime_clip_R1 {params.trim_3_r1} --three_prime_clip_R2 {params.trim_3_r2} --phred33 --length 20 -j {params.trim_cores} -o {params.FASTQtrimmeddir} --path_to_cutadapt cutadapt --paired {input.fastq1} {input.fastq2}"
+                "trim_galore -q 20 --clip_R1 {params.trim_5_r1} --clip_R2 {params.trim_5_r2} --three_prime_clip_R1 {params.trim_3_r1} --three_prime_clip_R2 {params.trim_3_r2} --phred33 --length 20 -j {params.trim_cores} -o {params.FASTQtrimmeddir} --path_to_cutadapt cutadapt --paired {input.fastq1} {input.fastq2} 2>&1 {log}"
                 if config["RUN_TRIMMING"]
-                else "trim_galore -q 20 --phred33 --length 20 -j {params.trim_cores} -o {params.FASTQtrimmeddir} --path_to_cutadapt cutadapt --paired {input.fastq1} {input.fastq2}"
+                else "trim_galore -q 20 --phred33 --length 20 -j {params.trim_cores} -o {params.FASTQtrimmeddir} --path_to_cutadapt cutadapt --paired {input.fastq1} {input.fastq2} 2>&1 {log}"
             )
         )

--- a/rules/trimming.smk
+++ b/rules/trimming.smk
@@ -15,7 +15,7 @@ rule trim_galore_se:
     output:
         o1=f"{OUTPUT_DIR}FASTQtrimmed/{{sample}}_trimmed.fq.gz",
     log:
-        f"{OUTPUT_DIR}/logs/trim_galore_{{sample}}_se.log",
+        f"{OUTPUT_DIR}logs/trim_galore_{{sample}}_se.log",
     params:
         FASTQtrimmeddir=lambda w, output: os.path.split(output.o1)[0],
         trim_5_r1=config["CLIP_5_R1"],
@@ -53,7 +53,7 @@ rule trim_galore_pe:
         o1=f"{OUTPUT_DIR}FASTQtrimmed/{{sample}}_{str(config['PAIR_1'])}_val_1.fq.gz",
         o2=f"{OUTPUT_DIR}FASTQtrimmed/{{sample}}_{str(config['PAIR_2'])}_val_2.fq.gz",
     log:
-        f"{OUTPUT_DIR}/logs/trim_galore_{{sample}}_pe.log",
+        f"{OUTPUT_DIR}logs/trim_galore_{{sample}}_pe.log",
     params:
         FASTQtrimmeddir=lambda w, output: os.path.split(output.o1)[0],
         trim_5_r1=config["CLIP_5_R1"],


### PR DESCRIPTION
This PR addresses the following issues:

- Major: all `log` files are now in the output directory instead of the ARPEGGIO folder
- Major: `log` files now include standard output and errors from each rules (before they were empty)
- Minor: benchmark filenames in `alignment.smk` are now unique